### PR TITLE
Schema skeleton

### DIFF
--- a/dbinit.sql
+++ b/dbinit.sql
@@ -53,6 +53,17 @@ BEGIN
 END
 $$ DELIMITER ;
 
+-- Update verifiedOn to current date when verified is set to true (1)
+DELIMITER $$
+CREATE TRIGGER userVerify_insert_verifid_date_after_update
+BEFORE UPDATE ON userVerify FOR EACH ROW
+BEGIN
+	IF NEW.verified = 1 AND NEW.verifiedOn IS NULL THEN
+		SET NEW.verifiedOn = NOW();
+	END IF;
+END
+$$ DELIMITER ;
+
 CREATE TABLE ranks (
 	rankId INT NOT NULL AUTO_INCREMENT,
     rankSlug VARCHAR(15) UNIQUE NOT NULL,


### PR DESCRIPTION
These recent updates should allow the userVerify table to run on versions of MySQL that don't allow functions to be used for column defaults. There are also some changes explained in the commits.