### PR TITLE
Add Punishments View

### DIFF
--- a/dbinit.sql
+++ b/dbinit.sql
@@ -216,22 +216,22 @@ CREATE TABLE logs (
 
 CREATE VIEW zanderdev.punishments AS
 SELECT
-	litebans.uuid AS bannedUuid,
+    litebans.uuid AS bannedUuid,
     banned.userId AS bannedUserId,
-	litebans.banned_by_uuid AS bannedByUuid,
+    litebans.banned_by_uuid AS bannedByUuid,
     banner.userId AS bannedByUserId,
-	litebans.removed_by_uuid AS removedByUuid,
+    litebans.removed_by_uuid AS removedByUuid,
     remover.userId AS removedByUserId,
-	litebans.type,
-	litebans.active,
-	litebans.silent,
+    litebans.type,
+    litebans.active,
+    litebans.silent,
     FROM_UNIXTIME(litebans.time/1000) AS dateStart,
     FROM_UNIXTIME(nullif((litebans.until / 1000), 0)) AS dateEnd,
     litebans.removed_by_date AS dateRemoved,
     litebans.reason,
     litebans.removed_by_reason AS reasonRemoved,
     litebans.ip,
-	litebans.ipban,
+    litebans.ipban,
     litebans.ipban_wildcard AS ipBanWildcard
 FROM (
 	SELECT

--- a/dbinit.sql
+++ b/dbinit.sql
@@ -213,3 +213,95 @@ CREATE TABLE logs (
     actionedDateTime DATETIME NOT NULL DEFAULT NOW(),
     PRIMARY KEY (logId)
 );
+
+CREATE VIEW zanderdev.punishments AS
+SELECT
+	litebans.uuid AS bannedUuid,
+    banned.userId AS bannedUserId,
+	litebans.banned_by_uuid AS bannedByUuid,
+    banner.userId AS bannedByUserId,
+	litebans.removed_by_uuid AS removedByUuid,
+    remover.userId AS removedByUserId,
+	litebans.type,
+	litebans.active,
+	litebans.silent,
+    FROM_UNIXTIME(litebans.time/1000) AS dateStart,
+    FROM_UNIXTIME(nullif((litebans.until / 1000), 0)) AS dateEnd,
+    litebans.removed_by_date AS dateRemoved,
+    litebans.reason,
+    litebans.removed_by_reason AS reasonRemoved,
+    litebans.ip,
+	litebans.ipban,
+    litebans.ipban_wildcard AS ipBanWildcard
+FROM (
+	SELECT
+		uuid,
+		ip,
+		reason,
+		banned_by_uuid,
+		time,
+		null AS until,
+		null AS removed_by_uuid,
+		null AS removed_by_reason,
+		null AS removed_by_date,
+		silent,
+		ipban,
+		ipban_wildcard,
+		null AS active,
+		'kick' AS type
+	FROM cfcdev_litebans.litebans_kicks
+	UNION
+	SELECT
+		uuid,
+		ip,
+		reason,
+		banned_by_uuid,
+		time,
+		until,
+		removed_by_uuid,
+		removed_by_reason,
+		removed_by_date,
+		silent,
+		ipban,
+		ipban_wildcard,
+		active,
+		'ban' AS type
+	FROM cfcdev_litebans.litebans_bans
+	UNION
+	SELECT
+		uuid,
+		ip,
+		reason,
+		banned_by_uuid,
+		time,
+		until,
+		removed_by_uuid,
+		removed_by_reason,
+		removed_by_date,
+		silent,
+		ipban,
+		ipban_wildcard,
+		active,
+		'mute' AS type
+	FROM cfcdev_litebans.litebans_mutes
+	UNION
+	SELECT
+		uuid,
+		ip,
+		reason,
+		banned_by_uuid,
+		time,
+		until,
+		removed_by_uuid,
+		removed_by_reason,
+		removed_by_date,
+		silent,
+		ipban,
+		ipban_wildcard,
+		active,
+		'warning' AS type
+	FROM cfcdev_litebans.litebans_warnings
+) AS litebans
+	LEFT JOIN zanderdev.users banned ON litebans.uuid = banned.uuid
+    LEFT JOIN zanderdev.users banner ON litebans.banned_by_uuid = banner.uuid
+    LEFT JOIN zanderdev.users remover ON litebans.removed_by_uuid = remover.uuid;


### PR DESCRIPTION
I have updated the dbinit.sql file to add query that creates a punishments view that pulls data from litebans.

The view is not live yet on the zanderdev server. My credentials don't have permission to create a view.
The dbinit.sql file is used to create the initial db.

So to add the punishments view to the existing database to begin writing code that uses it you will need to run that query separately. Here it is for ease of use:

```sql
CREATE VIEW zanderdev.punishments AS
SELECT
	litebans.uuid AS bannedUuid,
	banned.userId AS bannedUserId,
	litebans.banned_by_uuid AS bannedByUuid,
	banner.userId AS bannedByUserId,
	litebans.removed_by_uuid AS removedByUuid,
	remover.userId AS removedByUserId,
	litebans.type,
	litebans.active,
	litebans.silent,
	FROM_UNIXTIME(litebans.time/1000) AS dateStart,
	FROM_UNIXTIME(nullif((litebans.until / 1000), 0)) AS dateEnd,
	litebans.removed_by_date AS dateRemoved,
	litebans.reason,
	litebans.removed_by_reason AS reasonRemoved,
	litebans.ip,
	litebans.ipban,
	litebans.ipban_wildcard AS ipBanWildcard
FROM (
	SELECT
		uuid,
		ip,
		reason,
		banned_by_uuid,
		time,
		null AS until,
		null AS removed_by_uuid,
		null AS removed_by_reason,
		null AS removed_by_date,
		silent,
		ipban,
		ipban_wildcard,
		null AS active,
		'kick' AS type
	FROM cfcdev_litebans.litebans_kicks
	UNION
	SELECT
		uuid,
		ip,
		reason,
		banned_by_uuid,
		time,
		until,
		removed_by_uuid,
		removed_by_reason,
		removed_by_date,
		silent,
		ipban,
		ipban_wildcard,
		active,
		'ban' AS type
	FROM cfcdev_litebans.litebans_bans
	UNION
	SELECT
		uuid,
		ip,
		reason,
		banned_by_uuid,
		time,
		until,
		removed_by_uuid,
		removed_by_reason,
		removed_by_date,
		silent,
		ipban,
		ipban_wildcard,
		active,
		'mute' AS type
	FROM cfcdev_litebans.litebans_mutes
	UNION
	SELECT
		uuid,
		ip,
		reason,
		banned_by_uuid,
		time,
		until,
		removed_by_uuid,
		removed_by_reason,
		removed_by_date,
		silent,
		ipban,
		ipban_wildcard,
		active,
		'warning' AS type
	FROM cfcdev_litebans.litebans_warnings
) AS litebans
	LEFT JOIN zanderdev.users banned ON litebans.uuid = banned.uuid
    LEFT JOIN zanderdev.users banner ON litebans.banned_by_uuid = banner.uuid
    LEFT JOIN zanderdev.users remover ON litebans.removed_by_uuid = remover.uuid;
```