### PR TITLE
Add local registration flow with email and Minecraft verification

### DIFF
--- a/controllers/auditController.js
+++ b/controllers/auditController.js
@@ -64,7 +64,7 @@ export async function updateAudit_lastDiscordMessage(auditDateTime, discordId) {
       }
     );
 
-    console.log(`Discord account for this user is not linked, chat audit ignored.`);
+    console.warn(`Discord account for this user is not linked, chat audit ignored.`);
   }
 }
 
@@ -83,6 +83,6 @@ export async function updateAudit_lastDiscordVoice(auditDateTime, discordId) {
       }
     );
 
-    console.log(`Discord account for this user is not linked, chat audit ignored.`);    
+    console.warn(`Discord account for this user is not linked, chat audit ignored.`);
   }
 }

--- a/controllers/databaseController.js
+++ b/controllers/databaseController.js
@@ -16,11 +16,10 @@ var pool = mysql.createPool({
 
 pool.getConnection(function (err, connection) {
   if (err) {
-    console.log(err);    
     console.error(`[ERROR] [DB] There was an error connecting:\n ${err.stack}`);
     return;
   }
-  console.log(`[CONSOLE] [DB] Database pool connection is successful.`);
+  console.info(`[DB] Database pool connection is successful.`);
   connection.release(); // Release the connection back to the pool
 });
 

--- a/controllers/emailController.js
+++ b/controllers/emailController.js
@@ -41,7 +41,7 @@ export async function sendMail(
   try {
     await transporter.sendMail(mailOptions);
   } catch (error) {
-    console.log("Error occurred", error);
+    console.error("Failed to send email", error);
     throw error;
   }
 }

--- a/controllers/emailController.js
+++ b/controllers/emailController.js
@@ -5,15 +5,27 @@ import fs from "fs";
 import path from "path";
 dotenv.config();
 
+const smtpPort = Number(process.env.smtpPort) || 587;
+const smtpSecure = String(process.env.smtpSecure || "").toLowerCase() === "true";
+const smtpRequireTLS = String(process.env.smtpRequireTLS || "true").toLowerCase() === "true";
+
 const transporter = nodemailer.createTransport({
   host: process.env.smtpHost,
-  port: process.env.smtpPort,
-  secure: true,
+  port: smtpPort,
+  secure: smtpSecure,
+  requireTLS: !smtpSecure && smtpRequireTLS,
   auth: {
     user: process.env.smtpUser,
     pass: process.env.smtpPass,
   },
+  tls: {
+    minVersion: process.env.smtpTLSMinVersion || "TLSv1.2",
+  },
 });
+
+console.info(
+  `[EMAIL] Transport configured for ${process.env.smtpHost}:${smtpPort} secure=${smtpSecure} requireTLS=${!smtpSecure && smtpRequireTLS}`
+);
 
 export async function sendMail(
   recipient,

--- a/controllers/emailController.js
+++ b/controllers/emailController.js
@@ -2,6 +2,7 @@ import dotenv from "dotenv";
 import nodemailer from "nodemailer";
 import ejs from "ejs";
 import fs from "fs";
+import path from "path";
 dotenv.config();
 
 const transporter = nodemailer.createTransport({
@@ -16,27 +17,33 @@ const transporter = nodemailer.createTransport({
 
 export async function sendMail(
   recipient,
-  subject
+  subject,
+  template,
+  templateData = {}
 ) {
-  const emailTemplate = ejs.compile(
-    fs.readFileSync("./views/partials/email/emailTemplate.ejs", "utf-8")
+  const templatePath = path.resolve(
+    "views",
+    "partials",
+    "email",
+    template
   );
-  const renderedTemplate = emailTemplate({ username: "John" });
+
+  const templateContent = fs.readFileSync(templatePath, "utf-8");
+  const renderedTemplate = ejs.render(templateContent, templateData);
 
   const mailOptions = {
-    from: `"${process.env.smtpIdentityDisplayName}" <${process.env.smtpIdentityEmailAddress}>`, // sender address
-    to: recipient, // list of receivers
-    subject: subject, // Subject line
+    from: `"${process.env.smtpIdentityDisplayName}" <${process.env.smtpIdentityEmailAddress}>`,
+    to: recipient,
+    subject: subject,
     html: renderedTemplate,
   };
 
-  transporter.sendMail(mailOptions, (error, info) => {
-    if (error) {
-      return console.log("Error occurred", error);
-    } else {
-      return console.log("Email sent", info.response);
-    }
-  });
+  try {
+    await transporter.sendMail(mailOptions);
+  } catch (error) {
+    console.log("Error occurred", error);
+    throw error;
+  }
 }
 
 

--- a/controllers/emailController.js
+++ b/controllers/emailController.js
@@ -39,9 +39,34 @@ export async function sendMail(
   };
 
   try {
-    await transporter.sendMail(mailOptions);
+    console.info(
+      `[EMAIL] Sending template "${template}" to ${recipient} via ${process.env.smtpHost}:${process.env.smtpPort}`
+    );
+
+    const info = await transporter.sendMail(mailOptions);
+
+    const messageId = info?.messageId ? ` (messageId: ${info.messageId})` : "";
+    console.info(
+      `[EMAIL] Successfully sent template "${template}" to ${recipient}${messageId}`
+    );
+
+    if (info?.rejected?.length) {
+      console.warn(
+        `[EMAIL] SMTP rejected the following recipients: ${info.rejected.join(", ")}`
+      );
+    }
+
+    return info;
   } catch (error) {
-    console.error("Failed to send email", error);
+    const message = error?.message || error;
+    console.error(
+      `[EMAIL] Failed to send template "${template}" to ${recipient}: ${message}`
+    );
+
+    if (error?.response) {
+      console.error(`[EMAIL] SMTP response: ${error.response}`);
+    }
+
     throw error;
   }
 }

--- a/controllers/sessionController.js
+++ b/controllers/sessionController.js
@@ -1,10 +1,88 @@
+import bcrypt from "bcrypt";
+import db from "./databaseController.js";
+
 export async function generateVerificationCode() {
   return new Promise((resolve, reject) => {
     try {
       const code = Math.floor(100000 + Math.random() * 900000);
-      resolve(code);
+      resolve(code.toString());
     } catch (error) {
       reject(error);
     }
+  });
+}
+
+export async function createEmailVerification(userId, code, expiresAt) {
+  const hashedCode = await bcrypt.hash(code, 10);
+
+  return new Promise((resolve, reject) => {
+    db.query(
+      `DELETE FROM userEmailVerifications WHERE userId = ?`,
+      [userId],
+      function (deleteError) {
+        if (deleteError) {
+          return reject(deleteError);
+        }
+
+        db.query(
+          `INSERT INTO userEmailVerifications (userId, codeHash, expiresAt) VALUES (?, ?, ?)`,
+          [userId, hashedCode, expiresAt],
+          function (error) {
+            if (error) {
+              return reject(error);
+            }
+
+            resolve(true);
+          }
+        );
+      }
+    );
+  });
+}
+
+export async function verifyEmailCode(userId, code) {
+  return new Promise((resolve, reject) => {
+    db.query(
+      `SELECT * FROM userEmailVerifications WHERE userId = ? ORDER BY createdAt DESC LIMIT 1`,
+      [userId],
+      async function (error, results) {
+        if (error) {
+          return reject(error);
+        }
+
+        if (!results || !results.length) {
+          return resolve({ valid: false });
+        }
+
+        const verification = results[0];
+
+        if (verification.consumed) {
+          return resolve({ valid: false, reason: "consumed" });
+        }
+
+        const expiryDate = new Date(verification.expiresAt);
+        if (expiryDate < new Date()) {
+          return resolve({ valid: false, reason: "expired" });
+        }
+
+        const match = await bcrypt.compare(code, verification.codeHash);
+
+        if (!match) {
+          return resolve({ valid: false, reason: "mismatch" });
+        }
+
+        db.query(
+          `UPDATE userEmailVerifications SET consumed = 1, consumedAt = NOW() WHERE verificationId = ?`,
+          [verification.verificationId],
+          function (updateError) {
+            if (updateError) {
+              return reject(updateError);
+            }
+
+            resolve({ valid: true });
+          }
+        );
+      }
+    );
   });
 }

--- a/controllers/sessionController.js
+++ b/controllers/sessionController.js
@@ -86,3 +86,78 @@ export async function verifyEmailCode(userId, code) {
     );
   });
 }
+
+export async function createPasswordResetRequest(userId, code, expiresAt) {
+  const hashedCode = await bcrypt.hash(code, 10);
+
+  return new Promise((resolve, reject) => {
+    db.query(
+      `DELETE FROM userPasswordResets WHERE userId = ?`,
+      [userId],
+      function (deleteError) {
+        if (deleteError) {
+          return reject(deleteError);
+        }
+
+        db.query(
+          `INSERT INTO userPasswordResets (userId, codeHash, expiresAt) VALUES (?, ?, ?)`,
+          [userId, hashedCode, expiresAt],
+          function (error) {
+            if (error) {
+              return reject(error);
+            }
+
+            resolve(true);
+          }
+        );
+      }
+    );
+  });
+}
+
+export async function verifyPasswordResetCode(userId, code) {
+  return new Promise((resolve, reject) => {
+    db.query(
+      `SELECT * FROM userPasswordResets WHERE userId = ? ORDER BY createdAt DESC LIMIT 1`,
+      [userId],
+      async function (error, results) {
+        if (error) {
+          return reject(error);
+        }
+
+        if (!results || !results.length) {
+          return resolve({ valid: false });
+        }
+
+        const resetRequest = results[0];
+
+        if (resetRequest.consumed) {
+          return resolve({ valid: false, reason: "consumed" });
+        }
+
+        const expiryDate = new Date(resetRequest.expiresAt);
+        if (expiryDate < new Date()) {
+          return resolve({ valid: false, reason: "expired" });
+        }
+
+        const match = await bcrypt.compare(code, resetRequest.codeHash);
+
+        if (!match) {
+          return resolve({ valid: false, reason: "mismatch" });
+        }
+
+        db.query(
+          `UPDATE userPasswordResets SET consumed = 1, consumedAt = NOW() WHERE resetId = ?`,
+          [resetRequest.resetId],
+          function (updateError) {
+            if (updateError) {
+              return reject(updateError);
+            }
+
+            resolve({ valid: true });
+          }
+        );
+      }
+    );
+  });
+}

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -22,6 +22,55 @@ export function UserGetter() {
     });
   };
 
+  this.byEmail = function (email) {
+    return new Promise((resolve, reject) => {
+      db.query(
+        `SELECT * FROM users WHERE LOWER(email)=LOWER(?);`,
+        [email],
+        function (error, results) {
+          if (error) {
+            reject(error);
+          }
+
+          if (!results || !results.length) {
+            resolve(null);
+          } else {
+            resolve(results[0]);
+          }
+        }
+      );
+    });
+  };
+
+  this.byUserId = function (userId) {
+    return new Promise((resolve, reject) => {
+      db.query(
+        `SELECT * FROM users WHERE userId=?;`,
+        [userId],
+        function (error, results) {
+          if (error) {
+            reject(error);
+          }
+
+          if (!results || !results.length) {
+            resolve(null);
+          } else {
+            resolve(results[0]);
+          }
+        }
+      );
+    });
+  };
+
+  this.byUsernameOrEmail = async function (identifier) {
+    const byUsername = await this.byUsername(identifier);
+    if (byUsername) {
+      return byUsername;
+    }
+
+    return await this.byEmail(identifier);
+  };
+
   this.byUUID = function (uuid) {
     return new Promise((resolve, reject) => {
       db.query(
@@ -111,7 +160,7 @@ export function UserLinkGetter() {
   this.getUserByCode = function (code) {
     return new Promise((resolve, reject) => {
       db.query(
-        `SELECT u.* FROM users u JOIN userVerifyLink uv ON u.uuid = uv.uuid WHERE uv.linkCode = ?;`,
+        `SELECT u.*, uv.verifyId FROM users u JOIN userVerifyLink uv ON u.uuid = uv.uuid WHERE uv.linkCode = ? AND uv.codeExpiry > NOW();`,
         [code],
         function (error, results, fields) {
           if (error) {
@@ -138,11 +187,111 @@ export function UserLinkGetter() {
             reject(error);
           }
 
-          resolve(true);
+          db.query(
+            `DELETE FROM userVerifyLink WHERE uuid=?`,
+            [uuid],
+            function (deleteError) {
+              if (deleteError) {
+                return reject(deleteError);
+              }
+
+              resolve(true);
+            }
+          );
         }
       );
     });
   };
+
+  this.markWebsiteRegistrationComplete = function (uuid) {
+    return new Promise((resolve, reject) => {
+      db.query(
+        `UPDATE users SET account_registered=? WHERE uuid=?`,
+        [new Date(), uuid],
+        function (error) {
+          if (error) {
+            return reject(error);
+          }
+
+          db.query(
+            `DELETE FROM userVerifyLink WHERE uuid=?`,
+            [uuid],
+            function (deleteError) {
+              if (deleteError) {
+                return reject(deleteError);
+              }
+
+              resolve(true);
+            }
+          );
+        }
+      );
+    });
+  };
+}
+
+export function createLocalUser({ uuid, username, email, passwordHash }) {
+  return new Promise((resolve, reject) => {
+    db.query(
+      `INSERT INTO users (uuid, username, email, password_hash) VALUES (?, ?, ?, ?)`,
+      [uuid, username, email, passwordHash],
+      function (error, results) {
+        if (error) {
+          return reject(error);
+        }
+
+        resolve({ userId: results.insertId });
+      }
+    );
+  });
+}
+
+export function updateLocalUserCredentials(userId, email, passwordHash) {
+  return new Promise((resolve, reject) => {
+    db.query(
+      `UPDATE users SET email = ?, password_hash = ? WHERE userId = ?`,
+      [email, passwordHash, userId],
+      function (error) {
+        if (error) {
+          return reject(error);
+        }
+
+        resolve(true);
+      }
+    );
+  });
+}
+
+export function markEmailVerified(userId) {
+  return new Promise((resolve, reject) => {
+    db.query(
+      `UPDATE users SET email_verified = 1, email_verified_at = NOW() WHERE userId = ?`,
+      [userId],
+      function (error) {
+        if (error) {
+          return reject(error);
+        }
+
+        resolve(true);
+      }
+    );
+  });
+}
+
+export function markAccountRegistered(userId) {
+  return new Promise((resolve, reject) => {
+    db.query(
+      `UPDATE users SET account_registered = NOW() WHERE userId = ?`,
+      [userId],
+      function (error) {
+        if (error) {
+          return reject(error);
+        }
+
+        resolve(true);
+      }
+    );
+  });
 }
 
 export async function getProfilePicture(username) {
@@ -295,6 +444,7 @@ export async function getUserPermissions(userData) {
             })
           );
 
+          userPermissions.userRanks = userRanks.map((rank) => rank.rankSlug);
           resolve(userPermissions);
         } catch (err) {
           reject(err);

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -367,7 +367,7 @@ export async function setProfileDisplayPreferences(
     [profilePicture_type, profilePicture_email, userId],
     function (error, results, fields) {
       if (error) {
-        console.log(error);
+        console.error("Failed to update profile display preferences", error);
       }
     }
   );
@@ -382,7 +382,7 @@ export async function setProfileUserInterests(
     [social_interests, userId],
     function (error, results, fields) {
       if (error) {
-        console.log(error);
+        console.error("Failed to update profile interests", error);
       }
     }
   );
@@ -414,7 +414,7 @@ export async function setProfileSocialConnections(
     ],
     function (error, results, fields) {
       if (error) {
-        console.log(error);
+        console.error("Failed to update social connections", error);
       }
     }
   );
@@ -429,10 +429,26 @@ export async function setProfileUserAboutMe(
     [social_aboutMe, userId],
     function (error, results, fields) {
       if (error) {
-        console.log(error);
+        console.error("Failed to update profile bio", error);
       }
     }
   );
+}
+
+export function updateUserPassword(userId, passwordHash) {
+  return new Promise((resolve, reject) => {
+    db.query(
+      `UPDATE users SET password_hash = ? WHERE userId = ?`,
+      [passwordHash, userId],
+      function (error) {
+        if (error) {
+          return reject(error);
+        }
+
+        resolve(true);
+      }
+    );
+  });
 }
 
 export async function getUserPermissions(userData) {

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -282,11 +282,37 @@ export function createLocalUser({ uuid, username, email, passwordHash }) {
   });
 }
 
-export function updateLocalUserCredentials(userId, email, passwordHash) {
+export function updateLocalUserCredentials(
+  userId,
+  { email, passwordHash, username }
+) {
   return new Promise((resolve, reject) => {
+    const updates = [];
+    const params = [];
+
+    if (typeof email !== "undefined") {
+      updates.push(`email = ?`);
+      params.push(email);
+    }
+
+    if (typeof passwordHash !== "undefined") {
+      updates.push(`password_hash = ?`);
+      params.push(passwordHash);
+    }
+
+    if (typeof username !== "undefined") {
+      updates.push(`username = ?`);
+      params.push(username);
+    }
+
+    updates.push(`email_verified = 0`);
+    updates.push(`email_verified_at = NULL`);
+
+    params.push(userId);
+
     db.query(
-      `UPDATE users SET email = ?, password_hash = ? WHERE userId = ?`,
-      [email, passwordHash, userId],
+      `UPDATE users SET ${updates.join(", ")} WHERE userId = ?`,
+      params,
       function (error) {
         if (error) {
           return reject(error);

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -110,24 +110,60 @@ export function UserGetter() {
     });
   };
 
-  this.hasJoined = function (username) {
-    return new Promise((resolve, reject) => {
-      db.query(
-        `select * from users where username=?;`,
-        [username],
-        function (error, results, fields) {
+  this.hasJoined = async function (username, uuid = null) {
+    const trimmedUsername = username ? username.trim() : null;
+    const trimmedUuid = uuid ? uuid.trim() : null;
+
+    const runQuery = (sql, params) =>
+      new Promise((resolve, reject) => {
+        db.query(sql, params, (error, results) => {
           if (error) {
-            reject(error);
+            return reject(error);
           }
 
-          if (!results || !results.length) {
-            resolve(false);
-          }
+          resolve(results || []);
+        });
+      });
 
-          resolve(true);
-        }
+    if (trimmedUsername) {
+      const usernameMatch = await runQuery(
+        `SELECT 1 FROM users WHERE LOWER(username) = LOWER(?) LIMIT 1`,
+        [trimmedUsername]
       );
-    });
+
+      if (usernameMatch.length) {
+        return true;
+      }
+    }
+
+    if (trimmedUuid) {
+      const uuidMatch = await runQuery(
+        `SELECT 1 FROM users WHERE uuid = ? LIMIT 1`,
+        [trimmedUuid]
+      );
+
+      if (uuidMatch.length) {
+        return true;
+      }
+    }
+
+    if (!trimmedUsername) {
+      return false;
+    }
+
+    const luckPermsParams = [trimmedUsername];
+    let luckPermsQuery =
+      `SELECT 1 FROM luckPermsPlayers WHERE LOWER(username) = LOWER(?) LIMIT 1`;
+
+    if (trimmedUuid) {
+      luckPermsQuery =
+        `SELECT 1 FROM luckPermsPlayers WHERE LOWER(username) = LOWER(?) OR uuid = UNHEX(REPLACE(?, '-', '')) LIMIT 1`;
+      luckPermsParams.push(trimmedUuid);
+    }
+
+    const luckPermsMatch = await runQuery(luckPermsQuery, luckPermsParams);
+
+    return luckPermsMatch.length > 0;
   };
 
   this.isRegistered = function (discordId) {

--- a/dbinit.sql
+++ b/dbinit.sql
@@ -50,6 +50,19 @@ CREATE TABLE userEmailVerifications (
     CONSTRAINT fk_userEmailVerifications_users FOREIGN KEY (userId) REFERENCES users(userId) ON DELETE CASCADE
 );
 
+CREATE TABLE userPasswordResets (
+        resetId INT NOT NULL AUTO_INCREMENT,
+    userId INT NOT NULL,
+    codeHash VARCHAR(255) NOT NULL,
+    expiresAt DATETIME NOT NULL,
+    consumed BOOLEAN DEFAULT 0,
+    createdAt DATETIME DEFAULT NOW(),
+    consumedAt DATETIME,
+    PRIMARY KEY (resetId),
+    INDEX userPasswordResets_userId (userId),
+    CONSTRAINT fk_userPasswordResets_users FOREIGN KEY (userId) REFERENCES users(userId) ON DELETE CASCADE
+);
+
 CREATE TABLE userVerifyLink (
         verifyId INT NOT NULL AUTO_INCREMENT,
     uuid VARCHAR(36) NOT NULL UNIQUE,

--- a/dbinit.sql
+++ b/dbinit.sql
@@ -3,15 +3,19 @@ CREATE DATABASE IF NOT EXISTS zanderdev;
 USE zanderdev;
 
 CREATE TABLE users (
-	userId INT NOT NULL AUTO_INCREMENT,
-	uuid VARCHAR(36) NOT NULL UNIQUE,
-	username VARCHAR(16) NOT NULL,
+        userId INT NOT NULL AUTO_INCREMENT,
+        uuid VARCHAR(36) NOT NULL UNIQUE,
+        username VARCHAR(16) NOT NULL,
     discordId VARCHAR(18),
-	joined DATETIME NOT NULL DEFAULT NOW(),
+    email VARCHAR(254) UNIQUE,
+    password_hash VARCHAR(255),
+    email_verified BOOLEAN DEFAULT 0,
+    email_verified_at DATETIME,
+        joined DATETIME NOT NULL DEFAULT NOW(),
     profilePicture_type ENUM('CRAFTATAR', 'GRAVATAR') DEFAULT 'CRAFTATAR',
     profilePicture_email VARCHAR(70),
     account_registered DATETIME,
-	account_disabled BOOLEAN DEFAULT 0,
+        account_disabled BOOLEAN DEFAULT 0,
     social_aboutMe MEDIUMTEXT,
     social_interests VARCHAR(50),
     social_discord VARCHAR(32),
@@ -29,12 +33,25 @@ CREATE TABLE users (
 	audit_lastMinecraftPunishment DATETIME,
 	audit_lastDiscordPunishment DATETIME,
 	audit_lastWebsiteLogin DATETIME,
-	PRIMARY KEY (userId),
-	INDEX users (uuid(8))
+        PRIMARY KEY (userId),
+        INDEX users (uuid(8))
+);
+
+CREATE TABLE userEmailVerifications (
+        verificationId INT NOT NULL AUTO_INCREMENT,
+    userId INT NOT NULL,
+    codeHash VARCHAR(255) NOT NULL,
+    expiresAt DATETIME NOT NULL,
+    consumed BOOLEAN DEFAULT 0,
+    createdAt DATETIME DEFAULT NOW(),
+    consumedAt DATETIME,
+    PRIMARY KEY (verificationId),
+    INDEX userEmailVerifications_userId (userId),
+    CONSTRAINT fk_userEmailVerifications_users FOREIGN KEY (userId) REFERENCES users(userId) ON DELETE CASCADE
 );
 
 CREATE TABLE userVerifyLink (
-	verifyId INT NOT NULL AUTO_INCREMENT,
+        verifyId INT NOT NULL AUTO_INCREMENT,
     uuid VARCHAR(36) NOT NULL UNIQUE,
     username TEXT NOT NULL,
     linkCode VARCHAR(6),

--- a/migration/v1.2.0_v1.3.0.sql
+++ b/migration/v1.2.0_v1.3.0.sql
@@ -1,0 +1,20 @@
+USE zanderdev;
+
+ALTER TABLE users
+    ADD email VARCHAR(254) UNIQUE,
+    ADD password_hash VARCHAR(255),
+    ADD email_verified BOOLEAN DEFAULT 0,
+    ADD email_verified_at DATETIME;
+
+CREATE TABLE IF NOT EXISTS userEmailVerifications (
+    verificationId INT NOT NULL AUTO_INCREMENT,
+    userId INT NOT NULL,
+    codeHash VARCHAR(255) NOT NULL,
+    expiresAt DATETIME NOT NULL,
+    consumed BOOLEAN DEFAULT 0,
+    createdAt DATETIME DEFAULT NOW(),
+    consumedAt DATETIME,
+    PRIMARY KEY (verificationId),
+    INDEX userEmailVerifications_userId (userId),
+    CONSTRAINT fk_userEmailVerifications_users FOREIGN KEY (userId) REFERENCES users(userId) ON DELETE CASCADE
+);

--- a/migration/v1.3.0_v1.4.0.sql
+++ b/migration/v1.3.0_v1.4.0.sql
@@ -1,0 +1,14 @@
+USE zanderdev;
+
+CREATE TABLE IF NOT EXISTS userPasswordResets (
+    resetId INT NOT NULL AUTO_INCREMENT,
+    userId INT NOT NULL,
+    codeHash VARCHAR(255) NOT NULL,
+    expiresAt DATETIME NOT NULL,
+    consumed BOOLEAN DEFAULT 0,
+    createdAt DATETIME DEFAULT NOW(),
+    consumedAt DATETIME,
+    PRIMARY KEY (resetId),
+    INDEX userPasswordResets_userId (userId),
+    CONSTRAINT fk_userPasswordResets_users FOREIGN KEY (userId) REFERENCES users(userId) ON DELETE CASCADE
+);

--- a/routes/dashboard/dashboard.js
+++ b/routes/dashboard/dashboard.js
@@ -89,8 +89,6 @@ export default function dashboardSiteRoute(app, config, features, lang) {
     });
     const apiData = await response.json();
 
-    console.log(apiData);
-
     res.view("dashboard/bridge", {
       pageTitle: `Dashboard - Bridge`,
       config: config,

--- a/routes/index.js
+++ b/routes/index.js
@@ -153,9 +153,6 @@ export default function applicationSiteRoutes(
     });
     const shopApiData = await shopResponse.json();
 
-    console.log(shopApiData.data[0].userData);
-    
-
     return res.view("shopdirectory", {
       pageTitle: `Shop Directory`,
       config: config,

--- a/routes/sessionRoutes.js
+++ b/routes/sessionRoutes.js
@@ -329,6 +329,22 @@ export default function sessionSiteRoute(
 
       const existingUuidUser = await userGetter.byUUID(formattedUuid);
 
+      if (!existingUuidUser) {
+        const hasJoinedServer = await userGetter.hasJoined(
+          username,
+          formattedUuid
+        );
+
+        if (!hasJoinedServer) {
+          setBannerCookie(
+            "danger",
+            "You need to join the Minecraft server before creating a website account.",
+            res
+          );
+          return res.redirect(`/register`);
+        }
+      }
+
       const existingEmail = await userGetter.byEmail(email);
       if (
         existingEmail &&

--- a/routes/sessionRoutes.js
+++ b/routes/sessionRoutes.js
@@ -596,10 +596,6 @@ export default function sessionSiteRoute(
     try {
       const userGetter = new UserGetter();
       const existingUsername = await userGetter.byUsername(username);
-      if (existingUsername && existingUsername.password_hash) {
-        setBannerCookie("danger", "That username is already registered.", res);
-        return res.redirect(`/register`);
-      }
 
       const profileResponse = await fetch(
         `https://api.mojang.com/users/profiles/minecraft/${encodeURIComponent(username)}`
@@ -623,6 +619,19 @@ export default function sessionSiteRoute(
       }
 
       const existingUuidUser = await userGetter.byUUID(formattedUuid);
+
+      if (
+        existingUsername &&
+        (!existingUuidUser || existingUsername.userId !== existingUuidUser.userId)
+      ) {
+        setBannerCookie("danger", "That username is already registered.", res);
+        return res.redirect(`/register`);
+      }
+
+      if (existingUuidUser && existingUuidUser.account_registered) {
+        setBannerCookie("danger", "An account already exists for this Minecraft player.", res);
+        return res.redirect(`/register`);
+      }
 
       if (!existingUuidUser) {
         const hasJoinedServer = await userGetter.hasJoined(
@@ -656,12 +665,11 @@ export default function sessionSiteRoute(
       let userId;
 
       if (existingUuidUser) {
-        if (existingUuidUser.password_hash) {
-          setBannerCookie("danger", "An account already exists for this Minecraft player.", res);
-          return res.redirect(`/register`);
-        }
-
-        await updateLocalUserCredentials(existingUuidUser.userId, email, passwordHash);
+        await updateLocalUserCredentials(existingUuidUser.userId, {
+          email,
+          passwordHash,
+          username,
+        });
         userId = existingUuidUser.userId;
       } else {
         const newUser = await createLocalUser({

--- a/routes/sessionRoutes.js
+++ b/routes/sessionRoutes.js
@@ -14,6 +14,7 @@ import {
   getUserPermissions,
   createLocalUser,
   updateLocalUserCredentials,
+  updateUserPassword,
   markEmailVerified,
   markAccountRegistered,
   UserLinkGetter,
@@ -23,6 +24,8 @@ import {
   createEmailVerification,
   generateVerificationCode,
   verifyEmailCode,
+  createPasswordResetRequest,
+  verifyPasswordResetCode,
 } from "../controllers/sessionController.js";
 import { sendMail } from "../controllers/emailController.js";
 
@@ -40,6 +43,7 @@ export default function sessionSiteRoute(
   // Session
   //
   const emailVerificationExpiryMinutes = 10;
+  const passwordResetExpiryMinutes = 10;
   const passwordRequirements = /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d).{8,}$/;
 
   const buildDiscordAuthorizeUrl = () => {
@@ -172,6 +176,7 @@ export default function sessionSiteRoute(
       }
 
       await hydrateUserSession(req, user);
+      delete req.session.passwordReset;
       setBannerCookie("success", "Logged in successfully.", res);
       return res.redirect(`${process.env.siteAddress}/`);
     } catch (error) {
@@ -243,18 +248,285 @@ export default function sessionSiteRoute(
           maxAge: 10 * 60 * 1000,
         });
 
-        console.log("User is unregistered, redirecting to /unregistered");
         return res.redirect(`/unregistered`);
       }
 
       const userLoginData = await userGetData.byDiscordId(userData.id);
       await hydrateUserSession(req, userLoginData);
+      delete req.session.passwordReset;
 
       return res.redirect(`${process.env.siteAddress}/`);
     } catch (error) {
       console.error("Error:", error);
       setBannerCookie("danger", "Discord authentication failed.", res);
       return res.redirect(`/login`);
+    }
+  });
+
+  app.get("/forgot-password", async function (req, res) {
+    if (!isFeatureWebRouteEnabled(features.web.login, req, res, features))
+      return;
+
+    if (req.session.user) {
+      return res.redirect(`/`);
+    }
+
+    return res.view("session/forgotPassword", {
+      pageTitle: `Forgot Password`,
+      config: config,
+      req: req,
+      features: features,
+      globalImage: await getGlobalImage(),
+      announcementWeb: await getWebAnnouncement(),
+    });
+  });
+
+  app.post("/forgot-password", async function (req, res) {
+    if (!isFeatureWebRouteEnabled(features.web.login, req, res, features))
+      return;
+
+    if (req.session.user) {
+      return res.redirect(`/`);
+    }
+
+    const identifier = req.body.identifier ? req.body.identifier.trim() : "";
+
+    if (!identifier) {
+      setBannerCookie(
+        "warning",
+        "Please provide a username or email address.",
+        res
+      );
+      return res.redirect(`/forgot-password`);
+    }
+
+    try {
+      const userGetter = new UserGetter();
+      const user = await userGetter.byUsernameOrEmail(identifier);
+
+      if (user && user.email && user.password_hash) {
+        const code = await generateVerificationCode();
+        const expiresAt = new Date(
+          Date.now() + passwordResetExpiryMinutes * 60 * 1000
+        );
+
+        await createPasswordResetRequest(user.userId, code, expiresAt);
+
+        await sendMail(
+          user.email,
+          `Reset your ${config.siteConfiguration.siteName} password`,
+          "passwordResetCode.ejs",
+          {
+            username: user.username,
+            code,
+            expiryMinutes: passwordResetExpiryMinutes,
+            siteAddress: process.env.siteAddress,
+            siteName: config.siteConfiguration.siteName,
+          }
+        );
+
+        req.session.passwordReset = {
+          userId: user.userId,
+          username: user.username,
+          email: user.email,
+          stage: "CODE",
+        };
+      } else {
+        req.session.passwordReset = {
+          stage: "CODE",
+        };
+      }
+
+      setBannerCookie(
+        "success",
+        "If an account exists with those details, we've emailed a verification code.",
+        res
+      );
+
+      return res.redirect(`/forgot-password/verify`);
+    } catch (error) {
+      console.error(error);
+      setBannerCookie(
+        "danger",
+        "We couldn't start a password reset right now. Please try again soon.",
+        res
+      );
+      return res.redirect(`/forgot-password`);
+    }
+  });
+
+  app.get("/forgot-password/verify", async function (req, res) {
+    if (!isFeatureWebRouteEnabled(features.web.login, req, res, features))
+      return;
+
+    const passwordReset = req.session.passwordReset;
+
+    if (!passwordReset || passwordReset.stage !== "CODE") {
+      return res.redirect(`/forgot-password`);
+    }
+
+    return res.view("session/forgotPasswordVerify", {
+      pageTitle: `Verify Reset Code`,
+      config: config,
+      req: req,
+      features: features,
+      globalImage: await getGlobalImage(),
+      announcementWeb: await getWebAnnouncement(),
+      username: passwordReset.username,
+      expiryMinutes: passwordResetExpiryMinutes,
+    });
+  });
+
+  app.post("/forgot-password/verify", async function (req, res) {
+    if (!isFeatureWebRouteEnabled(features.web.login, req, res, features))
+      return;
+
+    const passwordReset = req.session.passwordReset;
+
+    if (!passwordReset || passwordReset.stage !== "CODE") {
+      setBannerCookie(
+        "danger",
+        "Your reset request could not be found. Please start again.",
+        res
+      );
+      return res.redirect(`/forgot-password`);
+    }
+
+    const code = req.body.code ? req.body.code.trim() : "";
+
+    if (!code) {
+      setBannerCookie("warning", "Please enter the verification code.", res);
+      return res.redirect(`/forgot-password/verify`);
+    }
+
+    if (!passwordReset.userId) {
+      setBannerCookie("danger", "We couldn't verify that code.", res);
+      return res.redirect(`/forgot-password/verify`);
+    }
+
+    try {
+      const verification = await verifyPasswordResetCode(
+        passwordReset.userId,
+        code
+      );
+
+      if (!verification.valid) {
+        let message = "We couldn't verify that code.";
+
+        if (verification.reason === "expired") {
+          message = "That code has expired. Please request a new password reset.";
+        } else if (verification.reason === "consumed") {
+          message = "That code has already been used. Please request a new password reset.";
+        }
+
+        setBannerCookie("danger", message, res);
+        return res.redirect(`/forgot-password/verify`);
+      }
+
+      req.session.passwordReset.stage = "RESET";
+
+      setBannerCookie(
+        "success",
+        "Code verified! You can now choose a new password.",
+        res
+      );
+      return res.redirect(`/forgot-password/reset`);
+    } catch (error) {
+      console.error(error);
+      setBannerCookie(
+        "danger",
+        "We couldn't verify that code right now. Please try again soon.",
+        res
+      );
+      return res.redirect(`/forgot-password/verify`);
+    }
+  });
+
+  app.get("/forgot-password/reset", async function (req, res) {
+    if (!isFeatureWebRouteEnabled(features.web.login, req, res, features))
+      return;
+
+    const passwordReset = req.session.passwordReset;
+
+    if (
+      !passwordReset ||
+      passwordReset.stage !== "RESET" ||
+      !passwordReset.userId
+    ) {
+      return res.redirect(`/forgot-password`);
+    }
+
+    return res.view("session/resetPassword", {
+      pageTitle: `Choose a New Password`,
+      config: config,
+      req: req,
+      features: features,
+      globalImage: await getGlobalImage(),
+      announcementWeb: await getWebAnnouncement(),
+    });
+  });
+
+  app.post("/forgot-password/reset", async function (req, res) {
+    if (!isFeatureWebRouteEnabled(features.web.login, req, res, features))
+      return;
+
+    const passwordReset = req.session.passwordReset;
+
+    if (
+      !passwordReset ||
+      passwordReset.stage !== "RESET" ||
+      !passwordReset.userId
+    ) {
+      setBannerCookie(
+        "danger",
+        "Your reset request could not be found. Please start again.",
+        res
+      );
+      return res.redirect(`/forgot-password`);
+    }
+
+    const password = req.body.password || "";
+    const confirmPassword = req.body.confirmPassword || "";
+
+    if (!password || !confirmPassword) {
+      setBannerCookie("warning", "Please complete all password fields.", res);
+      return res.redirect(`/forgot-password/reset`);
+    }
+
+    if (password !== confirmPassword) {
+      setBannerCookie("danger", "Passwords do not match.", res);
+      return res.redirect(`/forgot-password/reset`);
+    }
+
+    if (!passwordRequirements.test(password)) {
+      setBannerCookie(
+        "warning",
+        "Password must be at least 8 characters and include uppercase, lowercase and a number.",
+        res
+      );
+      return res.redirect(`/forgot-password/reset`);
+    }
+
+    try {
+      const passwordHash = await bcrypt.hash(password, 12);
+      await updateUserPassword(passwordReset.userId, passwordHash);
+
+      delete req.session.passwordReset;
+
+      setBannerCookie(
+        "success",
+        "Your password has been reset. You can now sign in.",
+        res
+      );
+      return res.redirect(`/login`);
+    } catch (error) {
+      console.error(error);
+      setBannerCookie(
+        "danger",
+        "We couldn't reset your password right now. Please try again soon.",
+        res
+      );
+      return res.redirect(`/forgot-password/reset`);
     }
   });
 
@@ -604,7 +876,7 @@ export default function sessionSiteRoute(
       setBannerCookie("success", lang.session.userLogout, res);
       res.redirect(`${process.env.siteAddress}/`);
     } catch (err) {
-      console.log(err);
+      console.error("Failed to destroy session during logout", err);
       throw err;
     }
   });

--- a/routes/sessionRoutes.js
+++ b/routes/sessionRoutes.js
@@ -1,6 +1,7 @@
 import dotenv from "dotenv";
 dotenv.config();
 import qs from "querystring";
+import bcrypt from "bcrypt";
 import {
   isFeatureWebRouteEnabled,
   setBannerCookie,
@@ -10,10 +11,20 @@ import { getWebAnnouncement } from "../controllers/announcementController.js";
 import {
   UserGetter,
   getProfilePicture,
-  getRankPermissions,
   getUserPermissions,
+  createLocalUser,
+  updateLocalUserCredentials,
+  markEmailVerified,
+  markAccountRegistered,
+  UserLinkGetter,
 } from "../controllers/userController.js";
 import { updateAudit_lastWebsiteLogin } from "../controllers/auditController.js";
+import {
+  createEmailVerification,
+  generateVerificationCode,
+  verifyEmailCode,
+} from "../controllers/sessionController.js";
+import { sendMail } from "../controllers/emailController.js";
 
 export default function sessionSiteRoute(
   app,
@@ -28,11 +39,10 @@ export default function sessionSiteRoute(
   //
   // Session
   //
-  app.get("/login", async function (req, res) {
-    if (!isFeatureWebRouteEnabled(features.web.login, req, res, features))
-      return;
+  const emailVerificationExpiryMinutes = 10;
+  const passwordRequirements = /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d).{8,}$/;
 
-    // Redirect to Discord for authentication
+  const buildDiscordAuthorizeUrl = () => {
     const params = {
       client_id: process.env.discordClientId,
       redirect_uri: `${process.env.siteAddress}/login/callback`,
@@ -40,11 +50,142 @@ export default function sessionSiteRoute(
       scope: "identify",
     };
 
-    const authorizeUrl = `https://discord.com/api/oauth2/authorize?${qs.stringify(
-      params
-    )}`;
+    return `https://discord.com/api/oauth2/authorize?${qs.stringify(params)}`;
+  };
 
-    res.redirect(authorizeUrl);
+  const normaliseEmail = (email) => (email || "").trim().toLowerCase();
+
+  const formatMojangUuid = (rawUuid) => {
+    if (!rawUuid) return null;
+
+    const cleaned = rawUuid.replace(/-/g, "");
+    if (cleaned.length !== 32) {
+      return null;
+    }
+
+    return `${cleaned.substring(0, 8)}-${cleaned.substring(8, 12)}-${cleaned.substring(
+      12,
+      16
+    )}-${cleaned.substring(16, 20)}-${cleaned.substring(20)}`;
+  };
+
+  async function hydrateUserSession(req, userLoginData) {
+    const userPermissionData = await getUserPermissions(userLoginData);
+    const userRanks = userPermissionData.userRanks || [];
+
+    req.session.authenticated = true;
+    req.session.user = {
+      userId: userLoginData.userId,
+      username: userLoginData.username,
+      profilePicture: await getProfilePicture(userLoginData.username),
+      discordID: userLoginData.discordId,
+      uuid: userLoginData.uuid,
+      ranks: userRanks,
+      permissions: userPermissionData,
+    };
+
+    await updateAudit_lastWebsiteLogin(new Date(), userLoginData.username);
+  }
+
+  app.get("/login", async function (req, res) {
+    if (!isFeatureWebRouteEnabled(features.web.login, req, res, features))
+      return;
+
+    const discordAuthorizeUrl = buildDiscordAuthorizeUrl();
+
+    if (req.query.provider === "discord") {
+      return res.redirect(discordAuthorizeUrl);
+    }
+
+    return res.view("session/login", {
+      pageTitle: `Login`,
+      config: config,
+      req: req,
+      features: features,
+      globalImage: await getGlobalImage(),
+      announcementWeb: await getWebAnnouncement(),
+      discordAuthorizeUrl,
+    });
+  });
+
+  app.post("/login", async function (req, res) {
+    if (!isFeatureWebRouteEnabled(features.web.login, req, res, features))
+      return;
+
+    const identifier = req.body.identifier ? req.body.identifier.trim() : "";
+    const password = req.body.password || "";
+
+    if (!identifier || !password) {
+      setBannerCookie("warning", "Username/email and password are required.", res);
+      return res.redirect(`/login`);
+    }
+
+    try {
+      const userGetter = new UserGetter();
+      const user = await userGetter.byUsernameOrEmail(identifier);
+
+      if (!user || !user.password_hash) {
+        setBannerCookie("danger", "Invalid credentials.", res);
+        return res.redirect(`/login`);
+      }
+
+      if (user.account_disabled) {
+        setBannerCookie(
+          "danger",
+          "Your account is disabled. Please contact the team for assistance.",
+          res
+        );
+        return res.redirect(`/login`);
+      }
+
+      const passwordMatch = await bcrypt.compare(password, user.password_hash);
+
+      if (!passwordMatch) {
+        setBannerCookie("danger", "Invalid credentials.", res);
+        return res.redirect(`/login`);
+      }
+
+      if (!user.email_verified) {
+        req.session.pendingRegistration = {
+          userId: user.userId,
+          username: user.username,
+          email: user.email,
+          stage: "EMAIL",
+        };
+        setBannerCookie("warning", "Please verify your email to continue.", res);
+        return res.redirect(`/register/verify-email`);
+      }
+
+      if (!user.account_registered) {
+        req.session.pendingRegistration = {
+          userId: user.userId,
+          username: user.username,
+          email: user.email,
+          stage: "MINECRAFT",
+        };
+        setBannerCookie(
+          "warning",
+          "Please finish verifying your Minecraft account to continue.",
+          res
+        );
+        return res.redirect(`/register/minecraft`);
+      }
+
+      await hydrateUserSession(req, user);
+      setBannerCookie("success", "Logged in successfully.", res);
+      return res.redirect(`${process.env.siteAddress}/`);
+    } catch (error) {
+      console.error(error);
+      setBannerCookie("danger", "Unable to log in, please try again soon.", res);
+      return res.redirect(`/login`);
+    }
+  });
+
+  app.get("/login/discord", async function (req, res) {
+    if (!isFeatureWebRouteEnabled(features.web.login, req, res, features))
+      return;
+
+    return res.redirect(buildDiscordAuthorizeUrl());
   });
 
   app.get("/login/callback", async (req, res) => {
@@ -55,7 +196,6 @@ export default function sessionSiteRoute(
         throw new Error("Authorization code is missing");
       }
 
-      // Exchange authorization code for access token
       const tokenParams = {
         client_id: process.env.discordClientId,
         client_secret: process.env.discordClientSecret,
@@ -65,16 +205,13 @@ export default function sessionSiteRoute(
         scope: "identify",
       };
 
-      const tokenResponse = await fetch(
-        "https://discord.com/api/oauth2/token",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-          },
-          body: qs.stringify(tokenParams),
-        }
-      );
+      const tokenResponse = await fetch("https://discord.com/api/oauth2/token", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: qs.stringify(tokenParams),
+      });
 
       if (!tokenResponse.ok) {
         const errorText = `Failed to obtain access token: ${tokenResponse.status} ${tokenResponse.statusText}`;
@@ -83,7 +220,6 @@ export default function sessionSiteRoute(
       }
 
       const tokenData = await tokenResponse.json();
-      // Use the access token to fetch user data from Discord API
       const userResponse = await fetch("https://discord.com/api/users/@me", {
         headers: {
           Authorization: `${tokenData.token_type} ${tokenData.access_token}`,
@@ -96,44 +232,326 @@ export default function sessionSiteRoute(
         throw new Error(errorText);
       }
 
-      const userData = await userResponse.json();      
-      // Check if user is registered in your system
+      const userData = await userResponse.json();
       const userGetData = new UserGetter();
       const userIsRegistered = await userGetData.isRegistered(userData.id);
 
       if (!userIsRegistered) {
-        // Set a cookie for unregistered user
         res.cookie("discordId", userData.id, {
           path: "/",
           httpOnly: true,
-          maxAge: 10000, // Expires in 10 seconds
+          maxAge: 10 * 60 * 1000,
         });
 
         console.log("User is unregistered, redirecting to /unregistered");
         return res.redirect(`/unregistered`);
-      } else {
-        // User is registered, proceed with session setup
-        const userLoginData = await userGetData.byDiscordId(userData.id);
-        const userPermissionData = await getUserPermissions(userLoginData);
-        
-        req.session.authenticated = true;
-        req.session.user = {
-          userId: userLoginData.userId,
-          username: userLoginData.username,
-          profilePicture: await getProfilePicture(userLoginData.username),
-          discordID: userLoginData.discordId,
-          uuid: userLoginData.uuid,
-          ranks: userPermissionData.userRanks,
-          permissions: userPermissionData,
-        };
-
-        // Update user profile for auditing
-        await updateAudit_lastWebsiteLogin(new Date(), userLoginData.username);
-        return res.redirect(`${process.env.siteAddress}/`);
       }
+
+      const userLoginData = await userGetData.byDiscordId(userData.id);
+      await hydrateUserSession(req, userLoginData);
+
+      return res.redirect(`${process.env.siteAddress}/`);
     } catch (error) {
       console.error("Error:", error);
-      return res.status(500).send("Internal Server Error");
+      setBannerCookie("danger", "Discord authentication failed.", res);
+      return res.redirect(`/login`);
+    }
+  });
+
+  app.get("/register", async function (req, res) {
+    if (!isFeatureWebRouteEnabled(features.web.register, req, res, features))
+      return;
+
+    if (req.session.user) {
+      return res.redirect(`/`);
+    }
+
+    return res.view("session/register", {
+      pageTitle: `Register`,
+      config: config,
+      req: req,
+      features: features,
+      globalImage: await getGlobalImage(),
+      announcementWeb: await getWebAnnouncement(),
+    });
+  });
+
+  app.post("/register", async function (req, res) {
+    if (!isFeatureWebRouteEnabled(features.web.register, req, res, features))
+      return;
+
+    const username = req.body.username ? req.body.username.trim() : "";
+    const email = normaliseEmail(req.body.email);
+    const password = req.body.password || "";
+
+    if (!username || !email || !password) {
+      setBannerCookie("warning", "All fields are required.", res);
+      return res.redirect(`/register`);
+    }
+
+    if (!passwordRequirements.test(password)) {
+      setBannerCookie(
+        "warning",
+        "Password must be at least 8 characters and include uppercase, lowercase and a number.",
+        res
+      );
+      return res.redirect(`/register`);
+    }
+
+    try {
+      const userGetter = new UserGetter();
+      const existingUsername = await userGetter.byUsername(username);
+      if (existingUsername && existingUsername.password_hash) {
+        setBannerCookie("danger", "That username is already registered.", res);
+        return res.redirect(`/register`);
+      }
+
+      const profileResponse = await fetch(
+        `https://api.mojang.com/users/profiles/minecraft/${encodeURIComponent(username)}`
+      );
+
+      if (profileResponse.status === 204 || profileResponse.status === 404) {
+        setBannerCookie("danger", "We could not find that Minecraft username.", res);
+        return res.redirect(`/register`);
+      }
+
+      if (!profileResponse.ok) {
+        throw new Error("Failed to validate Minecraft username");
+      }
+
+      const profileData = await profileResponse.json();
+      const formattedUuid = formatMojangUuid(profileData.id);
+
+      if (!formattedUuid) {
+        setBannerCookie("danger", "Invalid Minecraft UUID returned.", res);
+        return res.redirect(`/register`);
+      }
+
+      const existingUuidUser = await userGetter.byUUID(formattedUuid);
+
+      const existingEmail = await userGetter.byEmail(email);
+      if (
+        existingEmail &&
+        existingEmail.password_hash &&
+        (!existingUuidUser || existingEmail.userId !== existingUuidUser.userId)
+      ) {
+        setBannerCookie("danger", "That email address is already in use.", res);
+        return res.redirect(`/register`);
+      }
+
+      const passwordHash = await bcrypt.hash(password, 12);
+
+      let userId;
+
+      if (existingUuidUser) {
+        if (existingUuidUser.password_hash) {
+          setBannerCookie("danger", "An account already exists for this Minecraft player.", res);
+          return res.redirect(`/register`);
+        }
+
+        await updateLocalUserCredentials(existingUuidUser.userId, email, passwordHash);
+        userId = existingUuidUser.userId;
+      } else {
+        const newUser = await createLocalUser({
+          uuid: formattedUuid,
+          username,
+          email,
+          passwordHash,
+        });
+        userId = newUser.userId;
+      }
+
+      const verificationCode = await generateVerificationCode();
+      const expiresAt = new Date(Date.now() + emailVerificationExpiryMinutes * 60000);
+      await createEmailVerification(userId, verificationCode, expiresAt);
+
+      await sendMail(
+        email,
+        `${config.siteConfiguration.siteName} Email Verification`,
+        "verificationCode.ejs",
+        {
+          username,
+          code: verificationCode,
+          expiryMinutes: emailVerificationExpiryMinutes,
+          siteName: config.siteConfiguration.siteName,
+        }
+      );
+
+      req.session.pendingRegistration = {
+        userId,
+        username,
+        email,
+        stage: "EMAIL",
+      };
+
+      setBannerCookie("success", "We sent a verification code to your email.", res);
+      return res.redirect(`/register/verify-email`);
+    } catch (error) {
+      console.error(error);
+      setBannerCookie("danger", "We were unable to create your account.", res);
+      return res.redirect(`/register`);
+    }
+  });
+
+  app.get("/register/verify-email", async function (req, res) {
+    if (!isFeatureWebRouteEnabled(features.web.register, req, res, features))
+      return;
+
+    const pendingRegistration = req.session.pendingRegistration;
+
+    if (!pendingRegistration || !pendingRegistration.userId) {
+      setBannerCookie("warning", "Start by creating an account first.", res);
+      return res.redirect(`/register`);
+    }
+
+    return res.view("session/registerVerifyEmail", {
+      pageTitle: `Verify Email`,
+      config: config,
+      req: req,
+      features: features,
+      globalImage: await getGlobalImage(),
+      announcementWeb: await getWebAnnouncement(),
+      email: pendingRegistration.email,
+      expiryMinutes: emailVerificationExpiryMinutes,
+    });
+  });
+
+  app.post("/register/verify-email", async function (req, res) {
+    if (!isFeatureWebRouteEnabled(features.web.register, req, res, features))
+      return;
+
+    const pendingRegistration = req.session.pendingRegistration;
+    if (!pendingRegistration || !pendingRegistration.userId) {
+      setBannerCookie("warning", "Start by creating an account first.", res);
+      return res.redirect(`/register`);
+    }
+
+    const code = [
+      req.body.first,
+      req.body.second,
+      req.body.third,
+      req.body.fourth,
+      req.body.fifth,
+      req.body.sixth,
+    ]
+      .join("")
+      .trim();
+
+    if (code.length !== 6) {
+      setBannerCookie("danger", "Please enter the 6 digit code from your email.", res);
+      return res.redirect(`/register/verify-email`);
+    }
+
+    try {
+      const verificationResult = await verifyEmailCode(pendingRegistration.userId, code);
+
+      if (!verificationResult.valid) {
+        setBannerCookie("danger", "That verification code is invalid or expired.", res);
+        return res.redirect(`/register/verify-email`);
+      }
+
+      await markEmailVerified(pendingRegistration.userId);
+      req.session.pendingRegistration.stage = "MINECRAFT";
+
+      setBannerCookie(
+        "success",
+        "Email verified! Now verify your Minecraft account.",
+        res
+      );
+      return res.redirect(`/register/minecraft`);
+    } catch (error) {
+      console.error(error);
+      setBannerCookie("danger", "We were unable to verify that code.", res);
+      return res.redirect(`/register/verify-email`);
+    }
+  });
+
+  app.get("/register/minecraft", async function (req, res) {
+    if (!isFeatureWebRouteEnabled(features.web.register, req, res, features))
+      return;
+
+    const pendingRegistration = req.session.pendingRegistration;
+
+    if (!pendingRegistration || !pendingRegistration.userId) {
+      setBannerCookie("warning", "Start by creating an account first.", res);
+      return res.redirect(`/register`);
+    }
+
+    if (pendingRegistration.stage !== "MINECRAFT") {
+      setBannerCookie("warning", "Please verify your email before continuing.", res);
+      return res.redirect(`/register/verify-email`);
+    }
+
+    const fetchURL = `${process.env.siteAddress}/api/server/get?type=VERIFICATION`;
+    const response = await fetch(fetchURL, {
+      headers: { "x-access-token": process.env.apiKey },
+    });
+    const apiData = await response.json();
+
+    return res.view("session/registerMinecraft", {
+      pageTitle: `Verify Minecraft`,
+      config: config,
+      req: req,
+      apiData: apiData,
+      features: features,
+      globalImage: await getGlobalImage(),
+      announcementWeb: await getWebAnnouncement(),
+      pendingUserId: pendingRegistration.userId,
+    });
+  });
+
+  app.post("/register/minecraft", async function (req, res) {
+    if (!isFeatureWebRouteEnabled(features.web.register, req, res, features))
+      return;
+
+    const pendingRegistration = req.session.pendingRegistration;
+
+    if (!pendingRegistration || !pendingRegistration.userId) {
+      setBannerCookie("warning", "Start by creating an account first.", res);
+      return res.redirect(`/register`);
+    }
+
+    const code = [
+      req.body.first,
+      req.body.second,
+      req.body.third,
+      req.body.fourth,
+      req.body.fifth,
+      req.body.sixth,
+    ]
+      .join("")
+      .trim();
+
+    if (code.length !== 6) {
+      setBannerCookie("danger", "Please enter the 6 digit code from the Minecraft server.", res);
+      return res.redirect(`/register/minecraft`);
+    }
+
+    try {
+      const userLinkData = new UserLinkGetter();
+      const linkUser = await userLinkData.getUserByCode(code);
+
+      if (!linkUser || linkUser.userId !== pendingRegistration.userId) {
+        setBannerCookie(
+          "danger",
+          "That verification code does not match your account.",
+          res
+        );
+        return res.redirect(`/register/minecraft`);
+      }
+
+      await userLinkData.markWebsiteRegistrationComplete(linkUser.uuid);
+      await markAccountRegistered(pendingRegistration.userId);
+
+      await hydrateUserSession(req, linkUser);
+      delete req.session.pendingRegistration;
+
+      setBannerCookie("success", "Your account has been verified!", res);
+      return res.redirect(`${process.env.siteAddress}/`);
+    } catch (error) {
+      console.error(error);
+      setBannerCookie("danger", "Unable to verify that code right now.", res);
+      return res.redirect(`/register/minecraft`);
     }
   });
 
@@ -142,7 +560,7 @@ export default function sessionSiteRoute(
       return;
 
     const discordId = req.cookies.discordId;
-    if (!discordId) res.redirect(`/`);
+    if (!discordId) return res.redirect(`/`);
 
     const fetchURL = `${process.env.siteAddress}/api/server/get?type=VERIFICATION`;
     const response = await fetch(fetchURL, {

--- a/routes/sessionRoutes.js
+++ b/routes/sessionRoutes.js
@@ -73,6 +73,29 @@ export default function sessionSiteRoute(
     )}-${cleaned.substring(16, 20)}-${cleaned.substring(20)}`;
   };
 
+  const logRouteError = (context, error) => {
+    const message =
+      error && typeof error === "object" && "message" in error
+        ? error.message
+        : String(error ?? "Unknown error");
+
+    const details = [];
+    if (error && typeof error === "object") {
+      if ("code" in error && error.code) {
+        details.push(`code=${error.code}`);
+      }
+      if ("status" in error && error.status) {
+        details.push(`status=${error.status}`);
+      }
+      if ("responseCode" in error && error.responseCode) {
+        details.push(`responseCode=${error.responseCode}`);
+      }
+    }
+
+    const suffix = details.length ? ` (${details.join(", ")})` : "";
+    console.error(`[SESSION] ${context}: ${message}${suffix}`);
+  };
+
   async function hydrateUserSession(req, userLoginData) {
     const userPermissionData = await getUserPermissions(userLoginData);
     const userRanks = userPermissionData.userRanks || [];
@@ -180,7 +203,7 @@ export default function sessionSiteRoute(
       setBannerCookie("success", "Logged in successfully.", res);
       return res.redirect(`${process.env.siteAddress}/`);
     } catch (error) {
-      console.error(error);
+      logRouteError("local login attempt", error);
       setBannerCookie("danger", "Unable to log in, please try again soon.", res);
       return res.redirect(`/login`);
     }
@@ -220,7 +243,7 @@ export default function sessionSiteRoute(
 
       if (!tokenResponse.ok) {
         const errorText = `Failed to obtain access token: ${tokenResponse.status} ${tokenResponse.statusText}`;
-        console.error(errorText);
+        logRouteError("discord token exchange", errorText);
         throw new Error(errorText);
       }
 
@@ -233,7 +256,7 @@ export default function sessionSiteRoute(
 
       if (!userResponse.ok) {
         const errorText = `Failed to fetch user data: ${userResponse.status} ${userResponse.statusText}`;
-        console.error(errorText);
+        logRouteError("discord user fetch", errorText);
         throw new Error(errorText);
       }
 
@@ -257,7 +280,7 @@ export default function sessionSiteRoute(
 
       return res.redirect(`${process.env.siteAddress}/`);
     } catch (error) {
-      console.error("Error:", error);
+      logRouteError("discord OAuth callback", error);
       setBannerCookie("danger", "Discord authentication failed.", res);
       return res.redirect(`/login`);
     }
@@ -345,7 +368,7 @@ export default function sessionSiteRoute(
 
       return res.redirect(`/forgot-password/verify`);
     } catch (error) {
-      console.error(error);
+      logRouteError("start password reset", error);
       setBannerCookie(
         "danger",
         "We couldn't start a password reset right now. Please try again soon.",
@@ -432,7 +455,7 @@ export default function sessionSiteRoute(
       );
       return res.redirect(`/forgot-password/reset`);
     } catch (error) {
-      console.error(error);
+      logRouteError("verify password reset code", error);
       setBannerCookie(
         "danger",
         "We couldn't verify that code right now. Please try again soon.",
@@ -520,7 +543,7 @@ export default function sessionSiteRoute(
       );
       return res.redirect(`/login`);
     } catch (error) {
-      console.error(error);
+      logRouteError("complete password reset", error);
       setBannerCookie(
         "danger",
         "We couldn't reset your password right now. Please try again soon.",
@@ -621,6 +644,7 @@ export default function sessionSiteRoute(
       if (
         existingEmail &&
         existingEmail.password_hash &&
+        existingEmail.account_registered &&
         (!existingUuidUser || existingEmail.userId !== existingUuidUser.userId)
       ) {
         setBannerCookie("danger", "That email address is already in use.", res);
@@ -675,7 +699,7 @@ export default function sessionSiteRoute(
       setBannerCookie("success", "We sent a verification code to your email.", res);
       return res.redirect(`/register/verify-email`);
     } catch (error) {
-      console.error(error);
+      logRouteError("start registration", error);
       setBannerCookie("danger", "We were unable to create your account.", res);
       return res.redirect(`/register`);
     }
@@ -748,7 +772,7 @@ export default function sessionSiteRoute(
       );
       return res.redirect(`/register/minecraft`);
     } catch (error) {
-      console.error(error);
+      logRouteError("verify registration email", error);
       setBannerCookie("danger", "We were unable to verify that code.", res);
       return res.redirect(`/register/verify-email`);
     }
@@ -837,7 +861,7 @@ export default function sessionSiteRoute(
       setBannerCookie("success", "Your account has been verified!", res);
       return res.redirect(`${process.env.siteAddress}/`);
     } catch (error) {
-      console.error(error);
+      logRouteError("verify Minecraft registration", error);
       setBannerCookie("danger", "Unable to verify that code right now.", res);
       return res.redirect(`/register/minecraft`);
     }
@@ -876,7 +900,7 @@ export default function sessionSiteRoute(
       setBannerCookie("success", lang.session.userLogout, res);
       res.redirect(`${process.env.siteAddress}/`);
     } catch (err) {
-      console.error("Failed to destroy session during logout", err);
+      logRouteError("destroy session during logout", err);
       throw err;
     }
   });

--- a/views/partials/email/passwordResetCode.ejs
+++ b/views/partials/email/passwordResetCode.ejs
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= siteName %> Password Reset</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        background-color: #f4f4f4;
+        margin: 0;
+        padding: 0;
+      }
+      .container {
+        max-width: 600px;
+        margin: 40px auto;
+        background: #ffffff;
+        border-radius: 8px;
+        overflow: hidden;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      }
+      .header {
+        background-color: #007bff;
+        color: #ffffff;
+        padding: 24px;
+        text-align: center;
+      }
+      .content {
+        padding: 24px;
+        color: #333333;
+      }
+      .code {
+        font-size: 32px;
+        letter-spacing: 12px;
+        text-align: center;
+        font-weight: bold;
+        margin: 32px 0;
+        color: #007bff;
+      }
+      .footer {
+        padding: 16px;
+        text-align: center;
+        font-size: 12px;
+        color: #888888;
+      }
+      a.button {
+        display: inline-block;
+        margin-top: 16px;
+        padding: 12px 24px;
+        background-color: #007bff;
+        color: #ffffff;
+        text-decoration: none;
+        border-radius: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <h1><%= siteName %></h1>
+      </div>
+      <div class="content">
+        <p>Hello <strong><%= username %></strong>,</p>
+        <p>We received a request to reset your <%= siteName %> password. Enter the verification code below within <%= expiryMinutes %> minutes to continue.</p>
+        <div class="code"><%= code %></div>
+        <p>You can return to the site to enter this code at <a href="<%= siteAddress %>/forgot-password/verify"><%= siteAddress %>/forgot-password/verify</a>.</p>
+        <p>If you didn't request a password reset, you can safely ignore this email.</p>
+      </div>
+      <div class="footer">
+        &copy; <%= new Date().getFullYear() %> <%= siteName %>. All rights reserved.
+      </div>
+    </div>
+  </body>
+</html>

--- a/views/partials/email/verificationCode.ejs
+++ b/views/partials/email/verificationCode.ejs
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= siteName %> Email Verification</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        background-color: #f4f4f4;
+        margin: 0;
+        padding: 0;
+      }
+      .container {
+        max-width: 600px;
+        margin: 40px auto;
+        background: #ffffff;
+        border-radius: 8px;
+        overflow: hidden;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      }
+      .header {
+        background-color: #007bff;
+        color: #ffffff;
+        padding: 24px;
+        text-align: center;
+      }
+      .content {
+        padding: 24px;
+        color: #333333;
+      }
+      .code {
+        font-size: 32px;
+        letter-spacing: 12px;
+        text-align: center;
+        font-weight: bold;
+        margin: 32px 0;
+        color: #007bff;
+      }
+      .footer {
+        padding: 16px;
+        text-align: center;
+        font-size: 12px;
+        color: #888888;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <h1><%= siteName %></h1>
+      </div>
+      <div class="content">
+        <p>Hello <strong><%= username %></strong>,</p>
+        <p>Thanks for creating an account with <%= siteName %>! Enter the verification code below within <%= expiryMinutes %> minutes to confirm your email address.</p>
+        <div class="code"><%= code %></div>
+        <p>If you didn't request this, you can safely ignore this email.</p>
+      </div>
+      <div class="footer">
+        &copy; <%= new Date().getFullYear() %> <%= siteName %>. All rights reserved.
+      </div>
+    </div>
+  </body>
+</html>

--- a/views/session/forgotPassword.ejs
+++ b/views/session/forgotPassword.ejs
@@ -1,0 +1,48 @@
+<%- include("../modules/header.ejs", {
+    pageTitle: pageTitle,
+    pageDescription: "Reset your account password"
+}) %>
+
+<%- include("../modules/navigationBar.ejs") %>
+
+<%- include("../partials/miniHeader.ejs", {
+  headerTitle: "Forgot Password",
+  backgroundImage: globalImage
+}) %>
+
+<section class="section">
+  <div class="container">
+    <div class="row">
+      <div class="col-12 col-sm-6">
+        <% if (req.cookies.alertType) { %>
+          <%- include("../partials/alert.ejs", {
+            alertType: req.cookies.alertType,
+            content: req.cookies.alertContent
+          }) %>
+        <% } %>
+
+        <p class="text-muted">Enter your username or email address and we'll send you a verification code.</p>
+
+        <form method="post" action="<%= process.env.siteAddress %>/forgot-password">
+          <div class="mb-3">
+            <label for="identifier">Username or Email</label>
+            <input type="text" class="form-control" name="identifier" required>
+          </div>
+          <div class="text-center">
+            <button type="submit" class="btn btn-primary" style="width: 100%">Send Code</button>
+          </div>
+        </form>
+
+        <br>
+        <small class="text-muted">Remembered it? <a href="/login">Return to login</a>.</small>
+      </div>
+      <div class="col-12 col-sm-6" style="min-height:400px;">
+        <div class="text-center">
+          <img class="floating" style="margin-top:10px;" src="images/session/loginImage.png" height="280px" draggable="false">
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%- include("../modules/footer.ejs") %>

--- a/views/session/forgotPasswordVerify.ejs
+++ b/views/session/forgotPasswordVerify.ejs
@@ -1,0 +1,61 @@
+<%- include("../modules/header.ejs", {
+    pageTitle: pageTitle,
+    pageDescription: "Verify your password reset code"
+}) %>
+
+<%- include("../modules/navigationBar.ejs") %>
+
+<%- include("../partials/miniHeader.ejs", {
+  headerTitle: "Verify Reset Code",
+  backgroundImage: globalImage
+}) %>
+
+<section class="section">
+  <div class="container">
+    <div class="row">
+      <div class="col-12 col-sm-6">
+        <% if (req.cookies.alertType) { %>
+          <%- include("../partials/alert.ejs", {
+            alertType: req.cookies.alertType,
+            content: req.cookies.alertContent
+          }) %>
+        <% } %>
+
+        <p class="text-muted">
+          <% if (username) { %>
+            We've sent a verification code to the email associated with <strong><%= username %></strong>.
+          <% } else { %>
+            We've sent a verification code to the email on file if an account exists.
+          <% } %>
+          Enter the 6-digit code below. Codes are valid for <%= expiryMinutes %> minutes.
+        </p>
+
+        <form method="post" action="<%= process.env.siteAddress %>/forgot-password/verify">
+          <div class="mb-3">
+            <label for="code">Verification Code</label>
+            <input type="text" class="form-control" name="code" inputmode="numeric" maxlength="6" required>
+          </div>
+          <div class="text-center">
+            <button type="submit" class="btn btn-primary" style="width: 100%">Verify Code</button>
+          </div>
+        </form>
+
+        <br>
+        <small class="text-muted">Didn't receive a code? <a href="/forgot-password">Request another one</a>.</small>
+      </div>
+      <div class="col-12 col-sm-6" style="min-height:400px;">
+        <div class="text-center">
+          <img
+            class="floating"
+            style="margin-top:10px;"
+            src="images/session/registerImage.png"
+            height="280px"
+            draggable="false"
+          >
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%- include("../modules/footer.ejs") %>

--- a/views/session/login.ejs
+++ b/views/session/login.ejs
@@ -30,14 +30,16 @@
               <label for="password">Password</label>
               <input type="password" class="form-control" name="password" required>
             </div>
-            <div class="text-center">
-              <button type="submit" class="btn btn-primary" style="width: 100%">Sign In</button>
-            </div>
-          </form>
-          <br>
-          <div class="mb-3 text-center">
-            <span class="text-muted">or</span>
+          <div class="text-center">
+            <button type="submit" class="btn btn-primary" style="width: 100%">Sign In</button>
           </div>
+        </form>
+        <br>
+        <small class="text-muted">Forgot your password? <a href="/forgot-password">Reset it here</a>.</small>
+        <br>
+        <div class="mb-3 text-center">
+          <span class="text-muted">or</span>
+        </div>
           <div class="d-grid">
             <a href="<%= discordAuthorizeUrl %>" class="btn" style="background-color:#5865F2; color:#fff;">
               <i class="fab fa-discord"></i> Sign in with Discord

--- a/views/session/login.ejs
+++ b/views/session/login.ejs
@@ -23,8 +23,8 @@
 
           <form method="post" action="<%= process.env.siteAddress %>/login">
             <div class="mb-3">
-              <label for="username">Username</label>
-              <input type="text" class="form-control" name="username" required>
+              <label for="identifier">Username or Email</label>
+              <input type="text" class="form-control" name="identifier" required>
             </div>
             <div class="mb-3">
               <label for="password">Password</label>
@@ -34,6 +34,15 @@
               <button type="submit" class="btn btn-primary" style="width: 100%">Sign In</button>
             </div>
           </form>
+          <br>
+          <div class="mb-3 text-center">
+            <span class="text-muted">or</span>
+          </div>
+          <div class="d-grid">
+            <a href="<%= discordAuthorizeUrl %>" class="btn" style="background-color:#5865F2; color:#fff;">
+              <i class="fab fa-discord"></i> Sign in with Discord
+            </a>
+          </div>
           <br>
           <small class="text-muted">Don't have an account? You can <a href="/register">register here</a>.</small>
         </div>

--- a/views/session/register.ejs
+++ b/views/session/register.ejs
@@ -1,0 +1,54 @@
+<%- include("../modules/header.ejs", {
+    pageTitle: pageTitle,
+    pageDescription: "Register and join the community!"
+}) %>
+
+<%- include("../modules/navigationBar.ejs") %>
+
+<%- include("../partials/miniHeader.ejs", {
+  headerTitle: "Create an account",
+  backgroundImage: globalImage
+}) %>
+
+<section class="section">
+  <div class="container">
+    <div class="row">
+      <div class="col-12 col-md-6">
+        <% if (req.cookies.alertType) { %>
+          <%- include("../partials/alert.ejs", {
+            alertType: req.cookies.alertType,
+            content: req.cookies.alertContent
+          }) %>
+        <% } %>
+
+        <form method="post" action="<%= process.env.siteAddress %>/register">
+          <div class="mb-3">
+            <label for="username" class="form-label">Minecraft Username</label>
+            <input type="text" class="form-control" id="username" name="username" maxlength="16" required>
+          </div>
+          <div class="mb-3">
+            <label for="email" class="form-label">Email Address</label>
+            <input type="email" class="form-control" id="email" name="email" required>
+          </div>
+          <div class="mb-3">
+            <label for="password" class="form-label">Password</label>
+            <input type="password" class="form-control" id="password" name="password" required>
+            <small class="form-text text-muted">Password must be at least 8 characters long and include an uppercase letter, lowercase letter, and a number.</small>
+          </div>
+          <div class="text-center">
+            <button type="submit" class="btn btn-primary" style="width: 100%">Create Account</button>
+          </div>
+        </form>
+        <br>
+        <small class="text-muted">Already have an account? <a href="/login">Sign in here</a>.</small>
+      </div>
+      <div class="col-12 col-md-6" style="min-height:500px;">
+        <div class="text-center">
+          <img class="floating" style="margin-top:10px; max-width:100%; height:auto;" src="images/session/registerImage.png" draggable="false" alt="Register illustration">
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%- include("../modules/footer.ejs") %>

--- a/views/session/registerMinecraft.ejs
+++ b/views/session/registerMinecraft.ejs
@@ -1,0 +1,96 @@
+<%- include("../modules/header.ejs", {
+    pageTitle: pageTitle,
+    pageDescription: "Verify your Minecraft account to finish registration."
+}) %>
+
+<%- include("../modules/navigationBar.ejs") %>
+
+<%- include("../partials/miniHeader.ejs", {
+  headerTitle: "Minecraft Verification",
+  backgroundImage: globalImage
+}) %>
+
+<section class="section">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-12 col-md-6" style="margin-top: 10px;">
+        <% if (req.cookies.alertType) { %>
+          <%- include("../partials/alert.ejs", {
+            alertType: req.cookies.alertType,
+            content: req.cookies.alertContent
+          }) %>
+        <% } %>
+
+        <p>Join one of the verification servers below using the Minecraft account you registered with. The server will give you a secret 6 digit code. Enter it here to finish verifying your account.</p>
+
+        <% if (apiData.success == false) { %>
+          <%- include("../partials/alert.ejs", {
+            alertType: "danger",
+            content: apiData.message
+          }) %>
+        <% } else { %>
+          <% apiData.data.forEach(function (verifyServer) { %>
+            <div class="feature-item mb-4">
+              <h4 class="mb-2"><%= verifyServer.displayName %></h4>
+              <input type="text" class="form-control input-default text-center" value="<%= verifyServer.serverConnectionAddress %>" disabled>
+            </div>
+          <% }) %>
+        <% } %>
+
+        <form id="verificationForm" method="post" action="<%= process.env.siteAddress %>/register/minecraft">
+          <div id="otp" class="inputs d-flex flex-row justify-content-center mt-4">
+            <input class="m-2 text-center form-control rounded" type="text" name="first" maxlength="1" autocomplete="off" required />
+            <input class="m-2 text-center form-control rounded" type="text" name="second" maxlength="1" autocomplete="off" required />
+            <input class="m-2 text-center form-control rounded" type="text" name="third" maxlength="1" autocomplete="off" required />
+            <input class="m-2 text-center form-control rounded" type="text" name="fourth" maxlength="1" autocomplete="off" required />
+            <input class="m-2 text-center form-control rounded" type="text" name="fifth" maxlength="1" autocomplete="off" required />
+            <input class="m-2 text-center form-control rounded" type="text" name="sixth" maxlength="1" autocomplete="off" required />
+          </div>
+          <div class="text-center mt-3">
+            <button id="submitButton" type="submit" class="btn btn-primary" disabled>Verify Minecraft Account</button>
+          </div>
+        </form>
+
+        <script>
+          function moveToNextInput(currentInput) {
+            var maxLength = parseInt(currentInput.getAttribute('maxlength'));
+            if (currentInput.value.length >= maxLength) {
+              var nextInput = currentInput.nextElementSibling;
+              if (nextInput !== null) {
+                nextInput.focus();
+              }
+            }
+            validateInputs();
+          }
+
+          function validateInputs() {
+            var inputs = document.querySelectorAll('#otp input');
+            var isFilled = true;
+            inputs.forEach(function(input) {
+              if (input.value === '') {
+                isFilled = false;
+              }
+            });
+            document.getElementById('submitButton').disabled = !isFilled;
+          }
+
+          document.addEventListener('DOMContentLoaded', function() {
+            var inputs = document.querySelectorAll('#otp input');
+            inputs.forEach(function(input) {
+              input.addEventListener('input', function() {
+                moveToNextInput(this);
+              });
+            });
+          });
+        </script>
+      </div>
+      <div class="col-12 col-md-6" style="min-height:500px; display: flex; align-items: center;">
+        <div class="text-center">
+          <img class="floating" style="max-width: 100%; height: auto; margin-top:10px;" src="images/session/registerImage.png" draggable="false" alt="Minecraft verification illustration">
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%- include("../modules/footer.ejs") %>

--- a/views/session/registerVerifyEmail.ejs
+++ b/views/session/registerVerifyEmail.ejs
@@ -1,0 +1,82 @@
+<%- include("../modules/header.ejs", {
+    pageTitle: pageTitle,
+    pageDescription: "Verify your email to continue registration."
+}) %>
+
+<%- include("../modules/navigationBar.ejs") %>
+
+<%- include("../partials/miniHeader.ejs", {
+  headerTitle: "Verify your email",
+  backgroundImage: globalImage
+}) %>
+
+<section class="section">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-12 col-md-6" style="margin-top: 10px;">
+        <% if (req.cookies.alertType) { %>
+          <%- include("../partials/alert.ejs", {
+            alertType: req.cookies.alertType,
+            content: req.cookies.alertContent
+          }) %>
+        <% } %>
+
+        <p>We sent a 6 digit verification code to <strong><%= email %></strong>. Enter the code below within <%= expiryMinutes %> minutes to continue.</p>
+
+        <form method="post" action="<%= process.env.siteAddress %>/register/verify-email">
+          <div id="otp" class="inputs d-flex flex-row justify-content-center mt-2">
+            <input class="m-2 text-center form-control rounded" type="text" name="first" maxlength="1" autocomplete="off" required />
+            <input class="m-2 text-center form-control rounded" type="text" name="second" maxlength="1" autocomplete="off" required />
+            <input class="m-2 text-center form-control rounded" type="text" name="third" maxlength="1" autocomplete="off" required />
+            <input class="m-2 text-center form-control rounded" type="text" name="fourth" maxlength="1" autocomplete="off" required />
+            <input class="m-2 text-center form-control rounded" type="text" name="fifth" maxlength="1" autocomplete="off" required />
+            <input class="m-2 text-center form-control rounded" type="text" name="sixth" maxlength="1" autocomplete="off" required />
+          </div>
+          <div class="text-center mt-3">
+            <button type="submit" class="btn btn-primary" id="submitButton" disabled>Verify Email</button>
+          </div>
+        </form>
+
+        <script>
+          function moveToNextInput(currentInput) {
+            var maxLength = parseInt(currentInput.getAttribute('maxlength'));
+            if (currentInput.value.length >= maxLength) {
+              var nextInput = currentInput.nextElementSibling;
+              if (nextInput !== null) {
+                nextInput.focus();
+              }
+            }
+            validateInputs();
+          }
+
+          function validateInputs() {
+            var inputs = document.querySelectorAll('#otp input');
+            var isFilled = true;
+            inputs.forEach(function(input) {
+              if (input.value === '') {
+                isFilled = false;
+              }
+            });
+            document.getElementById('submitButton').disabled = !isFilled;
+          }
+
+          document.addEventListener('DOMContentLoaded', function() {
+            var inputs = document.querySelectorAll('#otp input');
+            inputs.forEach(function(input) {
+              input.addEventListener('input', function() {
+                moveToNextInput(this);
+              });
+            });
+          });
+        </script>
+      </div>
+      <div class="col-12 col-md-6" style="min-height:500px; display: flex; align-items: center;">
+        <div class="text-center">
+          <img class="floating" style="max-width: 100%; height: auto; margin-top:10px;" src="images/session/registerImage.png" draggable="false" alt="Email verification illustration">
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%- include("../modules/footer.ejs") %>

--- a/views/session/resetPassword.ejs
+++ b/views/session/resetPassword.ejs
@@ -1,0 +1,58 @@
+<%- include("../modules/header.ejs", {
+    pageTitle: pageTitle,
+    pageDescription: "Choose a new password"
+}) %>
+
+<%- include("../modules/navigationBar.ejs") %>
+
+<%- include("../partials/miniHeader.ejs", {
+  headerTitle: "Reset Password",
+  backgroundImage: globalImage
+}) %>
+
+<section class="section">
+  <div class="container">
+    <div class="row">
+      <div class="col-12 col-sm-6">
+        <% if (req.cookies.alertType) { %>
+          <%- include("../partials/alert.ejs", {
+            alertType: req.cookies.alertType,
+            content: req.cookies.alertContent
+          }) %>
+        <% } %>
+
+        <p class="text-muted">Choose a new password for your account. Make sure it meets our security requirements.</p>
+
+        <form method="post" action="<%= process.env.siteAddress %>/forgot-password/reset">
+          <div class="mb-3">
+            <label for="password">New Password</label>
+            <input type="password" class="form-control" name="password" required>
+          </div>
+          <div class="mb-3">
+            <label for="confirmPassword">Confirm Password</label>
+            <input type="password" class="form-control" name="confirmPassword" required>
+          </div>
+          <div class="text-center">
+            <button type="submit" class="btn btn-primary" style="width: 100%">Update Password</button>
+          </div>
+        </form>
+
+        <br>
+        <small class="text-muted">Know your password now? <a href="/login">Return to login</a>.</small>
+      </div>
+      <div class="col-12 col-sm-6" style="min-height:400px;">
+        <div class="text-center">
+          <img
+            class="floating"
+            style="margin-top:10px;"
+            src="images/session/registerImage.png"
+            height="280px"
+            draggable="false"
+          >
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%- include("../modules/footer.ejs") %>


### PR DESCRIPTION
## Summary
- add username/email authentication alongside the existing Discord OAuth login
- implement a multi-step registration flow with email code verification and Minecraft account validation screens
- extend the database and mailer to support storing credentials and sending verification emails

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_b_68e378a31dc4833098e9f0d9ad357ba9