### PR TITLE
Add in-game announcements for YouTube and Twitch creator events

### DIFF
--- a/controllers/watchController.js
+++ b/controllers/watchController.js
@@ -289,6 +289,25 @@ export function recordNotification(platform, externalContentId, notificationType
   });
 }
 
+/**
+ * Creates a temporary in-game tip announcement for a creator event.
+ * The announcement expires after `durationMinutes` (default 2 hours).
+ */
+export function createInGameAnnouncement(body, durationMinutes = 120) {
+  const endDate = new Date(Date.now() + durationMinutes * 60 * 1000);
+  const endDateStr = endDate.toISOString().slice(0, 19).replace("T", " ");
+  return new Promise((resolve, reject) => {
+    db.query(
+      `INSERT INTO announcements (enabled, announcementType, body, link, endDate) VALUES (1, 'tip', ?, ?, ?)`,
+      [body, "https://craftingforchrist.net/watch", endDateStr],
+      (error, results) => {
+        if (error) return reject(error);
+        resolve(results?.insertId || true);
+      }
+    );
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Eligibility helpers used by cron jobs
 // ---------------------------------------------------------------------------

--- a/cron/watchTwitchCron.js
+++ b/cron/watchTwitchCron.js
@@ -24,6 +24,7 @@ import {
   updateSyncStatus,
   hasNotificationBeenSent,
   recordNotification,
+  createInGameAnnouncement,
 } from "../controllers/watchController.js";
 
 // ---------------------------------------------------------------------------
@@ -198,6 +199,22 @@ async function syncTwitchCreator(creator, stream) {
           await recordNotification("twitch", stream.id, "live", messageId);
         } else {
           console.warn(`[WatchTwitch] userId=${creator.user_id}: notification failed for stream "${stream.id}" — will retry on next run.`);
+        }
+      }
+
+      // In-game tip announcement (deduplicated independently of Discord)
+      const ingameAlreadySent = await hasNotificationBeenSent("twitch", stream.id, "ingame_live");
+      if (ingameAlreadySent) {
+        console.log(`[WatchTwitch] userId=${creator.user_id}: in-game announcement already created for stream "${stream.id}" — skipping.`);
+      } else {
+        const creatorName = creator.platform_display_name || creator.username;
+        const announcementBody = `Creator ${creatorName} is now live — watch now at craftingforchrist.net/watch`;
+        try {
+          await createInGameAnnouncement(announcementBody);
+          await recordNotification("twitch", stream.id, "ingame_live", null);
+          console.log(`[WatchTwitch] userId=${creator.user_id}: in-game announcement created for stream "${stream.id}".`);
+        } catch (err) {
+          console.error(`[WatchTwitch] userId=${creator.user_id}: failed to create in-game announcement for stream "${stream.id}":`, err);
         }
       }
     } else {

--- a/cron/watchYoutubeCron.js
+++ b/cron/watchYoutubeCron.js
@@ -24,6 +24,7 @@ import {
   updateSyncStatus,
   hasNotificationBeenSent,
   recordNotification,
+  createInGameAnnouncement,
 } from "../controllers/watchController.js";
 
 // ---------------------------------------------------------------------------
@@ -332,6 +333,25 @@ async function syncYoutubeCreator(creator, apiKey, fetchFn) {
           await recordNotification("youtube", video.id, notifType, messageId);
         } else {
           console.warn(`[WatchYouTube] userId=${creator.user_id}: notification failed for "${video.id}" — will retry on next run.`);
+        }
+      }
+
+      // In-game tip announcement (deduplicated independently of Discord)
+      const ingameNotifType = `ingame_${notifType}`;
+      const ingameAlreadySent = await hasNotificationBeenSent("youtube", video.id, ingameNotifType);
+      if (ingameAlreadySent) {
+        console.log(`[WatchYouTube] userId=${creator.user_id}: in-game announcement already created for "${video.id}" — skipping.`);
+      } else {
+        const creatorName = creator.platform_display_name || creator.username;
+        const announcementBody = isCurrentlyLive
+          ? `Creator ${creatorName} is now live — watch now at craftingforchrist.net/watch`
+          : `Creator ${creatorName} has released a new video — watch now at craftingforchrist.net/watch`;
+        try {
+          await createInGameAnnouncement(announcementBody);
+          await recordNotification("youtube", video.id, ingameNotifType, null);
+          console.log(`[WatchYouTube] userId=${creator.user_id}: in-game announcement created for "${video.id}".`);
+        } catch (err) {
+          console.error(`[WatchYouTube] userId=${creator.user_id}: failed to create in-game announcement for "${video.id}":`, err);
         }
       }
     }

--- a/cron/watchYoutubeCron.js
+++ b/cron/watchYoutubeCron.js
@@ -311,6 +311,15 @@ async function syncYoutubeCreator(creator, apiKey, fetchFn) {
         continue;
       }
 
+      // Skip notifications for content that was already published before the
+      // creator linked their account — prevents a flood of announcements on
+      // first connection.  Currently-live streams are always announced since
+      // they are actively happening right now.
+      if (!isCurrentlyLive && publishedAt && creator.created_at && publishedAt < new Date(creator.created_at)) {
+        console.log(`[WatchYouTube] userId=${creator.user_id}: video "${video.id}" published before account connection (${publishedAt.toISOString()} < ${new Date(creator.created_at).toISOString()}) — skipping announcement.`);
+        continue;
+      }
+
       // Discord notifications
       const notifType = isCurrentlyLive ? "live" : "upload";
       const alreadySent = await hasNotificationBeenSent("youtube", video.id, notifType);


### PR DESCRIPTION
## Summary
This PR adds in-game tip announcements when creators go live or upload new videos. Announcements are created as temporary database entries that expire after 2 hours, and are deduplicated independently from Discord notifications.

## Key Changes
- **New controller function**: Added `createInGameAnnouncement()` in `watchController.js` that inserts temporary announcements into the database with a configurable duration (default 2 hours)
- **YouTube sync updates**: 
  - Added logic to skip notifications for content published before the creator linked their account (prevents announcement floods on first connection)
  - Added in-game announcement creation for both live streams and video uploads with appropriate messaging
- **Twitch sync updates**: Added in-game announcement creation for live streams with deduplication tracking
- **Deduplication**: In-game announcements use a separate notification type (`ingame_live`, `ingame_upload`) to track independently from Discord notifications

## Implementation Details
- Announcements are stored with `announcementType='tip'` and include a link to the watch page
- The `endDate` is calculated as current time + duration (default 120 minutes) and stored in ISO format
- Both YouTube and Twitch syncs follow the same pattern: check if announcement already sent, create if not, record the notification for future deduplication
- Error handling logs failures but doesn't block the sync process
- Creator display name falls back to username if platform display name is unavailable

https://claude.ai/code/session_012RBxpSY7EgRSY7MUSxg5Wt