### PR TITLE
Refactor staff audit report to use LuckPerms and add manual trigger command

### DIFF
--- a/commands/staffauditreport.mjs
+++ b/commands/staffauditreport.mjs
@@ -1,5 +1,5 @@
 import { Command } from "@sapphire/framework";
-import { Colors, EmbedBuilder } from "discord.js";
+import { Colors, EmbedBuilder, MessageFlags } from "discord.js";
 import { hasPermission } from "../lib/discord/permissions.mjs";
 import {
   getUserPermissions,
@@ -8,6 +8,8 @@ import {
 import { runStaffAuditReport } from "../cron/staffAuditReportCron.js";
 
 const AUDIT_PERMISSION_NODE = "zander.web.audit";
+
+console.log("[StaffAuditReport] Command file loaded.");
 
 export class StaffAuditReportCommand extends Command {
   constructor(context, options) {
@@ -23,26 +25,17 @@ export class StaffAuditReportCommand extends Command {
   }
 
   async chatInputRun(interaction) {
-    let deferred = false;
-    try {
-      await interaction.deferReply({ ephemeral: true });
-      deferred = true;
-    } catch (error) {
-      console.error("[StaffAuditReport] Failed to defer reply:", error);
-    }
+    console.log(`[StaffAuditReport] Invoked by ${interaction.user.tag}`);
 
-    const respond = (payload) => {
-      if (deferred) return interaction.editReply(payload);
-      return interaction.reply({ ...payload, ephemeral: true }).catch((err) => {
-        console.error("[StaffAuditReport] Failed to send reply:", err);
-      });
-    };
+    if (!interaction.deferred && !interaction.replied) {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    }
 
     const userGetter = new UserGetter();
     const linkedAccount = await userGetter.byDiscordId(interaction.user.id);
 
     if (!linkedAccount) {
-      return respond({
+      return interaction.editReply({
         embeds: [
           new EmbedBuilder()
             .setTitle("No Linked Account")
@@ -56,7 +49,7 @@ export class StaffAuditReportCommand extends Command {
 
     const userPermissions = await getUserPermissions(linkedAccount);
     if (!hasPermission(userPermissions, AUDIT_PERMISSION_NODE)) {
-      return respond({
+      return interaction.editReply({
         embeds: [
           new EmbedBuilder()
             .setTitle("No Permission")
@@ -70,7 +63,7 @@ export class StaffAuditReportCommand extends Command {
       await runStaffAuditReport();
     } catch (error) {
       console.error("[StaffAuditReport] Failed to run report:", error);
-      return respond({
+      return interaction.editReply({
         embeds: [
           new EmbedBuilder()
             .setTitle("Report Failed")
@@ -82,7 +75,7 @@ export class StaffAuditReportCommand extends Command {
       });
     }
 
-    return respond({
+    return interaction.editReply({
       embeds: [
         new EmbedBuilder()
           .setTitle("Staff Audit Report Sent")

--- a/commands/staffauditreport.mjs
+++ b/commands/staffauditreport.mjs
@@ -1,0 +1,89 @@
+import { Command } from "@sapphire/framework";
+import { Colors, EmbedBuilder } from "discord.js";
+import { hasPermission } from "../lib/discord/permissions.mjs";
+import {
+  getUserPermissions,
+  UserGetter,
+} from "../controllers/userController.js";
+import { runStaffAuditReport } from "../cron/staffAuditReportCron.js";
+
+const AUDIT_PERMISSION_NODE = "zander.web.audit";
+
+export class StaffAuditReportCommand extends Command {
+  constructor(context, options) {
+    super(context, { ...options });
+  }
+
+  registerApplicationCommands(registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder
+        .setName("staff-audit-report")
+        .setDescription("Manually trigger the staff activity audit report.")
+    );
+  }
+
+  async chatInputRun(interaction) {
+    try {
+      await interaction.deferReply({ ephemeral: true });
+    } catch (error) {
+      console.error("Failed to defer staff-audit-report reply", error);
+      return;
+    }
+
+    const userGetter = new UserGetter();
+    const linkedAccount = await userGetter.byDiscordId(interaction.user.id);
+
+    if (!linkedAccount) {
+      return interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle("No Linked Account")
+            .setDescription(
+              "Link your Minecraft account on the website before using this command."
+            )
+            .setColor(Colors.Red),
+        ],
+      });
+    }
+
+    const userPermissions = await getUserPermissions(linkedAccount);
+    if (!hasPermission(userPermissions, AUDIT_PERMISSION_NODE)) {
+      return interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle("No Permission")
+            .setDescription("You do not have access to use this command.")
+            .setColor(Colors.Red),
+        ],
+      });
+    }
+
+    try {
+      await runStaffAuditReport();
+    } catch (error) {
+      console.error("Failed to run staff audit report manually", error);
+      return interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle("Report Failed")
+            .setDescription(
+              "The staff audit report failed to run. Check server logs for details."
+            )
+            .setColor(Colors.Red),
+        ],
+      });
+    }
+
+    return interaction.editReply({
+      embeds: [
+        new EmbedBuilder()
+          .setTitle("Staff Audit Report Sent")
+          .setDescription(
+            "The staff activity audit report has been posted to the configured webhook."
+          )
+          .setColor(Colors.Green)
+          .setTimestamp(new Date()),
+      ],
+    });
+  }
+}

--- a/commands/staffauditreport.mjs
+++ b/commands/staffauditreport.mjs
@@ -59,8 +59,9 @@ export class StaffAuditReportCommand extends Command {
       });
     }
 
+    let result;
     try {
-      await runStaffAuditReport();
+      result = await runStaffAuditReport();
     } catch (error) {
       console.error("[StaffAuditReport] Failed to run report:", error);
       return interaction.editReply({
@@ -75,12 +76,23 @@ export class StaffAuditReportCommand extends Command {
       });
     }
 
+    if (!result.sent) {
+      return interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle("Report Not Sent")
+            .setDescription(result.reason)
+            .setColor(Colors.Orange),
+        ],
+      });
+    }
+
     return interaction.editReply({
       embeds: [
         new EmbedBuilder()
           .setTitle("Staff Audit Report Sent")
           .setDescription(
-            "The staff activity audit report has been posted to the configured webhook."
+            `Posted audit for **${result.staffCount}** staff member(s) across **${result.embedCount}** message(s).`
           )
           .setColor(Colors.Green)
           .setTimestamp(new Date()),

--- a/commands/staffauditreport.mjs
+++ b/commands/staffauditreport.mjs
@@ -23,18 +23,26 @@ export class StaffAuditReportCommand extends Command {
   }
 
   async chatInputRun(interaction) {
+    let deferred = false;
     try {
       await interaction.deferReply({ ephemeral: true });
+      deferred = true;
     } catch (error) {
-      console.error("Failed to defer staff-audit-report reply", error);
-      return;
+      console.error("[StaffAuditReport] Failed to defer reply:", error);
     }
+
+    const respond = (payload) => {
+      if (deferred) return interaction.editReply(payload);
+      return interaction.reply({ ...payload, ephemeral: true }).catch((err) => {
+        console.error("[StaffAuditReport] Failed to send reply:", err);
+      });
+    };
 
     const userGetter = new UserGetter();
     const linkedAccount = await userGetter.byDiscordId(interaction.user.id);
 
     if (!linkedAccount) {
-      return interaction.editReply({
+      return respond({
         embeds: [
           new EmbedBuilder()
             .setTitle("No Linked Account")
@@ -48,7 +56,7 @@ export class StaffAuditReportCommand extends Command {
 
     const userPermissions = await getUserPermissions(linkedAccount);
     if (!hasPermission(userPermissions, AUDIT_PERMISSION_NODE)) {
-      return interaction.editReply({
+      return respond({
         embeds: [
           new EmbedBuilder()
             .setTitle("No Permission")
@@ -61,8 +69,8 @@ export class StaffAuditReportCommand extends Command {
     try {
       await runStaffAuditReport();
     } catch (error) {
-      console.error("Failed to run staff audit report manually", error);
-      return interaction.editReply({
+      console.error("[StaffAuditReport] Failed to run report:", error);
+      return respond({
         embeds: [
           new EmbedBuilder()
             .setTitle("Report Failed")
@@ -74,7 +82,7 @@ export class StaffAuditReportCommand extends Command {
       });
     }
 
-    return interaction.editReply({
+    return respond({
       embeds: [
         new EmbedBuilder()
           .setTitle("Staff Audit Report Sent")

--- a/controllers/auditController.js
+++ b/controllers/auditController.js
@@ -23,6 +23,8 @@ export async function updateAudit_lastMinecraftMessage(auditDateTime, username) 
   const userData = new UserGetter();
   const userAudit = await userData.byUsername(username);
 
+  if (!userAudit) return;
+
   db.query(
     `UPDATE users SET audit_lastMinecraftMessage=? WHERE userId=?;`,
     [auditDateTime, userAudit.userId],
@@ -38,6 +40,8 @@ export async function updateAudit_lastWebsiteLogin(auditDateTime, username) {
   const userData = new UserGetter();
   const userAudit = await userData.byUsername(username);
 
+  if (!userAudit) return;
+
   db.query(
     `UPDATE users SET audit_lastWebsiteLogin=? WHERE userId=?;`,
     [auditDateTime, userAudit.userId],
@@ -52,7 +56,7 @@ export async function updateAudit_lastWebsiteLogin(auditDateTime, username) {
 export async function updateAudit_lastDiscordMessage(auditDateTime, discordId) {
   const userData = new UserGetter();
   const userAudit = await userData.byDiscordId(discordId);
-  
+
   if (userAudit) {
     db.query(
       `UPDATE users SET audit_lastDiscordMessage=? WHERE userId=?;`,
@@ -63,7 +67,7 @@ export async function updateAudit_lastDiscordMessage(auditDateTime, discordId) {
         }
       }
     );
-
+  } else {
     console.warn(`Discord account for this user is not linked, chat audit ignored.`);
   }
 }
@@ -82,7 +86,7 @@ export async function updateAudit_lastDiscordVoice(auditDateTime, discordId) {
         }
       }
     );
-
-    console.warn(`Discord account for this user is not linked, chat audit ignored.`);
+  } else {
+    console.warn(`Discord account for this user is not linked, voice audit ignored.`);
   }
 }

--- a/controllers/discordController.js
+++ b/controllers/discordController.js
@@ -1,5 +1,13 @@
-import { SapphireClient } from "@sapphire/framework";
+import { SapphireClient, ApplicationCommandRegistries, RegisterBehavior } from "@sapphire/framework";
 import { GatewayIntentBits } from "discord.js";
+
+// Use BulkOverwrite instead of the default per-command Overwrite.
+// The default behavior makes one Discord API call per command on every startup
+// (20+ commands = 20+ sequential HTTP round-trips), which congests the event
+// loop long enough for incoming interaction tokens to expire before the handler
+// can call deferReply, causing "application did not respond" errors.
+// BulkOverwrite replaces all of that with a single PUT call.
+ApplicationCommandRegistries.setDefaultBehaviorWhenNotIdentical(RegisterBehavior.BulkOverwrite);
 
 //
 // Discord

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -559,9 +559,13 @@ export async function getUserPermissions(userData = {}) {
   const queuedRankSet = new Set();
 
   const userId = userData?.userId || null;
-  const rawUuid = userData?.uuid || null;
+  // rawUuid is the LP-native UUID string (VARCHAR with dashes, e.g. "550e8400-e29b-41d4-a716-446655440000").
+  // LuckPerms MySQL stores uuid as VARCHAR(36) with dashes, so LP queries must use this value
+  // directly rather than UNHEX(hex-without-dashes), which would produce binary that never matches.
+  let rawUuid = userData?.uuid || null;
   const username = userData?.username || null;
 
+  // uuidHex is kept only as a non-null sentinel for the "do we have a UUID?" guards below.
   let uuidHex = normaliseUuid(rawUuid);
 
   const ensureUuid = async () => {
@@ -576,19 +580,22 @@ export async function getUserPermissions(userData = {}) {
       );
 
       if (rows.length && rows[0].uuid) {
+        rawUuid = rows[0].uuid;
         uuidHex = normaliseUuid(rows[0].uuid);
         return;
       }
     }
 
     if (username) {
+      // LP stores uuid as VARCHAR(36) with dashes — select it as-is, no HEX() conversion.
       const rows = await runLuckPermsQuery(
-        `SELECT LOWER(HEX(uuid)) AS uuid FROM ${LUCKPERMS_PLAYERS_TABLE} WHERE LOWER(username) = LOWER(?) LIMIT 1`,
+        `SELECT uuid FROM ${LUCKPERMS_PLAYERS_TABLE} WHERE LOWER(username) = LOWER(?) LIMIT 1`,
         [username]
       );
 
       if (rows.length && rows[0].uuid) {
-        uuidHex = rows[0].uuid;
+        rawUuid = rows[0].uuid;
+        uuidHex = normaliseUuid(rows[0].uuid);
       }
     }
   };
@@ -627,11 +634,11 @@ export async function getUserPermissions(userData = {}) {
       const directPermissions = await runLuckPermsQuery(
         `SELECT permission
            FROM ${LUCKPERMS_USER_PERMISSIONS_TABLE}
-          WHERE uuid = UNHEX(?)
+          WHERE uuid = ?
             AND permission NOT LIKE 'group.%'
             AND value = 1
             AND (expiry IS NULL OR expiry = 0 OR expiry > UNIX_TIMESTAMP())`,
-        [uuidHex]
+        [rawUuid]
       );
 
       directPermissions.forEach(({ permission }) => pushPermission(permission));
@@ -643,12 +650,12 @@ export async function getUserPermissions(userData = {}) {
       const rankRows = await runLuckPermsQuery(
         `SELECT SUBSTRING_INDEX(permission, '.', -1) AS rankSlug
            FROM ${LUCKPERMS_USER_PERMISSIONS_TABLE}
-          WHERE uuid = UNHEX(?)
+          WHERE uuid = ?
             AND permission LIKE 'group.%'
             AND value = 1
             AND (expiry IS NULL OR expiry = 0 OR expiry > UNIX_TIMESTAMP())
           ORDER BY permission`,
-        [uuidHex]
+        [rawUuid]
       );
 
       rankRows.forEach(({ rankSlug }) => queueRank(rankSlug, { direct: true }));
@@ -677,9 +684,9 @@ export async function getUserPermissions(userData = {}) {
       const primaryGroupRows = await runLuckPermsQuery(
         `SELECT primary_group AS rankSlug
            FROM ${LUCKPERMS_PLAYERS_TABLE}
-          WHERE uuid = UNHEX(?)
+          WHERE uuid = ?
           LIMIT 1`,
-        [uuidHex]
+        [rawUuid]
       );
 
       primaryGroupRows.forEach(({ rankSlug }) => queueRank(rankSlug, { direct: true }));

--- a/cron/staffAuditReportCron.js
+++ b/cron/staffAuditReportCron.js
@@ -48,56 +48,37 @@ function buildCronExpression() {
   return `${minute} ${hour} * * ${day}`;
 }
 
-function formatAuditTimestamp(value) {
-  if (!value) return "No record";
 
-  const timestamp = Math.floor(new Date(value).getTime() / 1000);
-  if (!Number.isFinite(timestamp)) return "No record";
+function buildMemberField(member) {
+  const ts = (val) => {
+    if (!val) return "_No record_";
+    const t = Math.floor(new Date(val).getTime() / 1000);
+    return Number.isFinite(t) ? `<t:${t}:R>` : "_No record_";
+  };
 
-  return `<t:${timestamp}:F> (<t:${timestamp}:R>)`;
-}
-
-function buildMemberSection(member) {
   const lines = [];
 
-  // Header: username + Discord mention
-  const headerParts = [`**${member.username}**`];
-  if (member.discordId) {
-    headerParts.push(`<@${member.discordId}>`);
-  }
-  lines.push(headerParts.join(" "));
+  // Account linkage
+  const mcStatus = member.uuid ? "✅ MC linked" : "❌ MC not linked";
+  const discordStatus = member.discordId ? `✅ <@${member.discordId}>` : "❌ Discord not linked";
+  lines.push(`${mcStatus} · ${discordStatus}`);
 
-  // Account linkage status
-  const mcLinked = member.uuid ? "✅ Linked" : "❌ Not linked";
-  const discordLinked = member.discordId ? "✅ Linked" : "❌ Not linked";
-  lines.push(`__Account Linkage:__ Minecraft: ${mcLinked} · Discord: ${discordLinked}`);
-
-  // Minecraft activity
-  lines.push("");
-  lines.push("**Minecraft**");
+  // Minecraft
   if (member.uuid) {
-    lines.push(`• Last Login: ${formatAuditTimestamp(member.audit_lastMinecraftLogin)}`);
-    lines.push(`• Last Message: ${formatAuditTimestamp(member.audit_lastMinecraftMessage)}`);
-    lines.push(`• Punishments: _Feature coming soon_`);
+    lines.push(`**Minecraft** — Login: ${ts(member.audit_lastMinecraftLogin)} · Chat: ${ts(member.audit_lastMinecraftMessage)}`);
   } else {
-    lines.push(`• _Account not linked — activity cannot be tracked_`);
+    lines.push("**Minecraft** — _not linked_");
   }
 
-  // Discord activity
-  lines.push("");
-  lines.push("**Discord**");
+  // Discord
   if (member.discordId) {
-    lines.push(`• Last Message: ${formatAuditTimestamp(member.audit_lastDiscordMessage)}`);
-    lines.push(`• Last Voice: ${formatAuditTimestamp(member.audit_lastDiscordVoice)}`);
-    lines.push(`• Punishments: _Feature coming soon_`);
+    lines.push(`**Discord** — Chat: ${ts(member.audit_lastDiscordMessage)} · Voice: ${ts(member.audit_lastDiscordVoice)}`);
   } else {
-    lines.push(`• _Account not linked — activity cannot be tracked_`);
+    lines.push("**Discord** — _not linked_");
   }
 
-  // Website activity
-  lines.push("");
-  lines.push("**Website**");
-  lines.push(`• Last Login: ${formatAuditTimestamp(member.audit_lastWebsiteLogin)}`);
+  // Website
+  lines.push(`**Website** — Login: ${ts(member.audit_lastWebsiteLogin)}`);
 
   return lines.join("\n");
 }
@@ -131,42 +112,6 @@ async function fetchActiveStaff() {
   });
 }
 
-function packIntoFields(sections) {
-  const MAX_FIELD_LENGTH = 1024;
-  const fields = [];
-  let buffer = "";
-
-  for (const section of sections) {
-    const candidate = buffer ? `${buffer}\n\n${section}` : section;
-
-    if (candidate.length > MAX_FIELD_LENGTH) {
-      if (buffer) fields.push(buffer);
-
-      if (section.length > MAX_FIELD_LENGTH) {
-        // Split oversized section by lines
-        let chunk = "";
-        for (const line of section.split("\n")) {
-          const lineCandidate = chunk ? `${chunk}\n${line}` : line;
-          if (lineCandidate.length > MAX_FIELD_LENGTH) {
-            if (chunk) fields.push(chunk);
-            chunk = line.length > MAX_FIELD_LENGTH ? line.slice(0, MAX_FIELD_LENGTH) : line;
-          } else {
-            chunk = lineCandidate;
-          }
-        }
-        if (chunk) fields.push(chunk);
-        buffer = "";
-      } else {
-        buffer = section;
-      }
-    } else {
-      buffer = candidate;
-    }
-  }
-
-  if (buffer) fields.push(buffer);
-  return fields;
-}
 
 export async function runStaffAuditReport() {
   // Check feature flag
@@ -194,26 +139,17 @@ export async function runStaffAuditReport() {
     return { sent: false, reason: "No active staff members were found." };
   }
 
-  // Build per-member sections
-  const sections = staffMembers.map(buildMemberSection);
-  const fieldValues = packIntoFields(sections);
-
-  if (!fieldValues.length) {
-    fieldValues.push("No audit data was available for staff members.");
-  }
-
-  // Discord embeds have a max of 25 fields and 6000 chars total
-  // Split into multiple embeds if needed
+  // Each member gets their own named field. Discord allows max 25 fields per
+  // embed, so split into multiple embeds if there are more than 25 staff.
   const embeds = [];
+  let embedIndex = 1;
   let currentEmbed = new EmbedBuilder()
     .setTitle("Weekly Staff Activity Audit")
     .setColor(Colors.Blurple)
     .setTimestamp(new Date());
-
   let fieldCount = 0;
-  let embedIndex = 1;
 
-  for (let i = 0; i < fieldValues.length; i++) {
+  for (const member of staffMembers) {
     if (fieldCount >= 25) {
       embeds.push(currentEmbed);
       embedIndex++;
@@ -225,8 +161,8 @@ export async function runStaffAuditReport() {
     }
 
     currentEmbed.addFields({
-      name: fieldCount === 0 && embedIndex === 1 ? "Staff Activity" : "\u200b",
-      value: fieldValues[i],
+      name: member.username,
+      value: buildMemberField(member),
       inline: false,
     });
     fieldCount++;

--- a/cron/staffAuditReportCron.js
+++ b/cron/staffAuditReportCron.js
@@ -1,7 +1,8 @@
 import cron from "node-cron";
-import { Colors, EmbedBuilder, WebhookClient } from "discord.js";
+import { Colors, EmbedBuilder } from "discord.js";
 import { createRequire } from "module";
 import db from "../controllers/databaseController.js";
+import { client } from "../controllers/discordController.js";
 
 const require = createRequire(import.meta.url);
 const config = require("../config.json");
@@ -180,12 +181,9 @@ export async function runStaffAuditReport() {
     return;
   }
 
-  // Get webhook URL from staffAuditReport config or discord.webhooks fallback
-  const webhookUrl = auditConfig.webhookUrl || config?.discord?.webhooks?.staffAuditLog;
-  if (!webhookUrl || webhookUrl === "WEBHOOKURL") {
-    console.warn(
-      "Staff audit report skipped: no valid webhook URL configured."
-    );
+  const channelId = auditConfig.channelId;
+  if (!channelId) {
+    console.warn("Staff audit report skipped: no channelId configured.");
     return;
   }
 
@@ -241,14 +239,9 @@ export async function runStaffAuditReport() {
   });
   embeds.push(currentEmbed);
 
-  // Send via webhook
-  const webhookClient = new WebhookClient({ url: webhookUrl });
-  try {
-    for (const embed of embeds) {
-      await webhookClient.send({ embeds: [embed] });
-    }
-  } finally {
-    webhookClient.destroy?.();
+  const channel = await client.channels.fetch(channelId);
+  for (const embed of embeds) {
+    await channel.send({ embeds: [embed] });
   }
 
   console.log(

--- a/cron/staffAuditReportCron.js
+++ b/cron/staffAuditReportCron.js
@@ -85,30 +85,16 @@ function buildMemberField(member) {
   return lines.join("\n");
 }
 
-async function fetchActiveStaff() {
-  // Step 1: fetch staff from main DB using the LP-backed views.
-  // LEFT JOIN users so LP members who haven't registered on the website
-  // still appear (userId/username will be NULL for them).
-  const rows = await new Promise((resolve, reject) => {
-    db.query(
-      `SELECT
-        ur.uuid,
-        u.userId,
-        u.username,
-        u.discordId,
-        u.audit_lastDiscordMessage,
-        u.audit_lastDiscordVoice,
-        u.audit_lastMinecraftLogin,
-        u.audit_lastMinecraftMessage,
-        u.audit_lastWebsiteLogin
-      FROM userRanks ur
-      JOIN ranks r ON r.rankSlug = ur.rankSlug
-      LEFT JOIN users u ON u.userId = ur.userId
-      WHERE r.isStaff = '1'
-        AND ur.rankSlug != 'retired'
-        AND (u.account_disabled IS NULL OR u.account_disabled = 0)
-      GROUP BY ur.uuid
-      ORDER BY u.username;`,
+async function fetchActiveStaff(staffGroups) {
+  if (!staffGroups?.length) return [];
+
+  // Step 1: query LP directly for UUIDs of members in any configured staff group.
+  const groupPermissions = staffGroups.map((g) => `group.${g}`);
+  const lpRows = await new Promise((resolve, reject) => {
+    luckpermsDb.query(
+      `SELECT DISTINCT uuid FROM luckperms_user_permissions
+       WHERE permission IN (?) AND value = 1`,
+      [groupPermissions],
       (error, results) => {
         if (error) return reject(error);
         resolve(results || []);
@@ -116,27 +102,53 @@ async function fetchActiveStaff() {
     );
   });
 
-  // Step 2: for members not registered on the website (username IS NULL),
-  // look up their username from the LP database (separate server).
-  const unnamedUuids = rows.filter((r) => !r.username).map((r) => r.uuid);
-  if (unnamedUuids.length > 0) {
-    const lpNames = await new Promise((resolve, reject) => {
-      luckpermsDb.query(
-        `SELECT uuid, username FROM luckperms_players WHERE uuid IN (?)`,
-        [unnamedUuids],
-        (error, results) => {
-          if (error) return reject(error);
-          resolve(results || []);
-        }
-      );
-    });
-    const nameMap = Object.fromEntries(lpNames.map((r) => [r.uuid, r.username]));
-    for (const row of rows) {
-      if (!row.username) row.username = nameMap[row.uuid] ?? row.uuid;
-    }
-  }
+  if (!lpRows.length) return [];
+  const uuids = lpRows.map((r) => r.uuid);
 
-  return rows.sort((a, b) => (a.username ?? "").localeCompare(b.username ?? ""));
+  // Step 2: get usernames from LP for all found UUIDs.
+  const lpPlayers = await new Promise((resolve, reject) => {
+    luckpermsDb.query(
+      `SELECT uuid, username FROM luckperms_players WHERE uuid IN (?)`,
+      [uuids],
+      (error, results) => {
+        if (error) return reject(error);
+        resolve(results || []);
+      }
+    );
+  });
+  const nameMap = Object.fromEntries(lpPlayers.map((r) => [r.uuid, r.username]));
+
+  // Step 3: get website/audit data from main DB for any matched users.
+  const websiteRows = await new Promise((resolve, reject) => {
+    db.query(
+      `SELECT
+        userId,
+        uuid,
+        discordId,
+        audit_lastDiscordMessage,
+        audit_lastDiscordVoice,
+        audit_lastMinecraftLogin,
+        audit_lastMinecraftMessage,
+        audit_lastWebsiteLogin
+      FROM users
+      WHERE uuid IN (?) AND account_disabled = 0`,
+      [uuids],
+      (error, results) => {
+        if (error) return reject(error);
+        resolve(results || []);
+      }
+    );
+  });
+  const websiteMap = Object.fromEntries(websiteRows.map((r) => [r.uuid, r]));
+
+  // Merge: one entry per UUID, LP username + website audit data where available.
+  return uuids
+    .map((uuid) => ({
+      uuid,
+      username: nameMap[uuid] ?? uuid,
+      ...websiteMap[uuid],
+    }))
+    .sort((a, b) => a.username.localeCompare(b.username));
 }
 
 
@@ -158,8 +170,13 @@ export async function runStaffAuditReport() {
     return { sent: false, reason: "No `channelId` is configured for the staff audit report." };
   }
 
+  const staffGroups = auditConfig.staffGroups;
+  if (!staffGroups?.length) {
+    return { sent: false, reason: "No `staffGroups` are configured. Add a list of LP group names e.g. `\"staffGroups\": [\"mod\", \"admin\"]`." };
+  }
+
   // Fetch staff data
-  const staffMembers = await fetchActiveStaff();
+  const staffMembers = await fetchActiveStaff(staffGroups);
 
   if (!staffMembers.length) {
     console.warn("Staff audit report skipped: no active staff members found.");

--- a/cron/staffAuditReportCron.js
+++ b/cron/staffAuditReportCron.js
@@ -58,27 +58,29 @@ function buildMemberField(member) {
 
   const lines = [];
 
-  // Account linkage
-  const mcStatus = member.uuid ? "✅ MC linked" : "❌ MC not linked";
-  const discordStatus = member.discordId ? `✅ <@${member.discordId}>` : "❌ Discord not linked";
-  lines.push(`${mcStatus} · ${discordStatus}`);
+  // Account linkage — uuid is always present (sourced from LP),
+  // but audit data only exists if the member is on the website (userId set).
+  const websiteLinked = !!member.userId;
+  const discordLinked = !!member.discordId;
+  const discordStatus = discordLinked ? `✅ <@${member.discordId}>` : "❌ Discord not linked";
+  lines.push(`${discordStatus}`);
 
-  // Minecraft
-  if (member.uuid) {
+  // Minecraft — always in LP, but activity only tracked if website-registered
+  if (websiteLinked) {
     lines.push(`**Minecraft** — Login: ${ts(member.audit_lastMinecraftLogin)} · Chat: ${ts(member.audit_lastMinecraftMessage)}`);
   } else {
-    lines.push("**Minecraft** — _not linked_");
+    lines.push("**Minecraft** — _not registered on website_");
   }
 
   // Discord
-  if (member.discordId) {
+  if (discordLinked) {
     lines.push(`**Discord** — Chat: ${ts(member.audit_lastDiscordMessage)} · Voice: ${ts(member.audit_lastDiscordVoice)}`);
   } else {
     lines.push("**Discord** — _not linked_");
   }
 
   // Website
-  lines.push(`**Website** — Login: ${ts(member.audit_lastWebsiteLogin)}`);
+  lines.push(`**Website** — Login: ${websiteLinked ? ts(member.audit_lastWebsiteLogin) : "_not registered_"}`);
 
   return lines.join("\n");
 }
@@ -87,23 +89,24 @@ async function fetchActiveStaff() {
   return new Promise((resolve, reject) => {
     db.query(
       `SELECT
+        ur.uuid,
+        COALESCE(u.username, lp.username) AS username,
         u.userId,
-        u.username,
-        u.uuid,
         u.discordId,
         u.audit_lastDiscordMessage,
         u.audit_lastDiscordVoice,
         u.audit_lastMinecraftLogin,
         u.audit_lastMinecraftMessage,
         u.audit_lastWebsiteLogin
-      FROM users u
-      JOIN userRanks ur ON ur.userId = u.userId
+      FROM userRanks ur
       JOIN ranks r ON r.rankSlug = ur.rankSlug
+      LEFT JOIN users u ON u.userId = ur.userId
+      LEFT JOIN cfcdev_luckperms.luckperms_players lp ON lp.uuid = ur.uuid
       WHERE r.isStaff = '1'
         AND ur.rankSlug != 'retired'
-        AND u.account_disabled = 0
-      GROUP BY u.userId
-      ORDER BY u.username;`,
+        AND (u.account_disabled IS NULL OR u.account_disabled = 0)
+      GROUP BY ur.uuid
+      ORDER BY COALESCE(u.username, lp.username);`,
       (error, results) => {
         if (error) return reject(error);
         resolve(results || []);

--- a/cron/staffAuditReportCron.js
+++ b/cron/staffAuditReportCron.js
@@ -114,8 +114,6 @@ async function fetchActiveStaff() {
         u.audit_lastDiscordVoice,
         u.audit_lastMinecraftLogin,
         u.audit_lastMinecraftMessage,
-        u.audit_lastMinecraftPunishment,
-        u.audit_lastDiscordPunishment,
         u.audit_lastWebsiteLogin
       FROM users u
       JOIN userRanks ur ON ur.userId = u.userId

--- a/cron/staffAuditReportCron.js
+++ b/cron/staffAuditReportCron.js
@@ -173,18 +173,19 @@ function packIntoFields(sections) {
 export async function runStaffAuditReport() {
   // Check feature flag
   if (!features.staffAuditReport) {
-    return;
+    return { sent: false, reason: "Feature is disabled." };
   }
 
   const auditConfig = config.staffAuditReport;
   if (!auditConfig?.enabled) {
-    return;
+    return { sent: false, reason: "Staff audit report is not enabled in config." };
   }
 
-  const channelId = auditConfig.channelId;
+  // Support both flat channelId and legacy delivery.channelId
+  const channelId = auditConfig.channelId || auditConfig.delivery?.channelId;
   if (!channelId) {
     console.warn("Staff audit report skipped: no channelId configured.");
-    return;
+    return { sent: false, reason: "No `channelId` is configured for the staff audit report." };
   }
 
   // Fetch staff data
@@ -192,7 +193,7 @@ export async function runStaffAuditReport() {
 
   if (!staffMembers.length) {
     console.warn("Staff audit report skipped: no active staff members found.");
-    return;
+    return { sent: false, reason: "No active staff members were found." };
   }
 
   // Build per-member sections
@@ -247,6 +248,8 @@ export async function runStaffAuditReport() {
   console.log(
     `Posted weekly staff audit report (${staffMembers.length} staff members, ${embeds.length} embed(s)).`
   );
+
+  return { sent: true, staffCount: staffMembers.length, embedCount: embeds.length };
 }
 
 // Build schedule from config

--- a/cron/staffAuditReportCron.js
+++ b/cron/staffAuditReportCron.js
@@ -56,31 +56,21 @@ function buildMemberField(member) {
     return Number.isFinite(t) ? `<t:${t}:R>` : "_No record_";
   };
 
-  const lines = [];
-
-  // Account linkage — uuid is always present (sourced from LP),
-  // but audit data only exists if the member is on the website (userId set).
   const websiteLinked = !!member.userId;
   const discordLinked = !!member.discordId;
-  const discordStatus = discordLinked ? `✅ <@${member.discordId}>` : "❌ Discord not linked";
-  lines.push(`${discordStatus}`);
+  const lines = [];
 
-  // Minecraft — always in LP, but activity only tracked if website-registered
-  if (websiteLinked) {
-    lines.push(`**Minecraft** — Login: ${ts(member.audit_lastMinecraftLogin)} · Chat: ${ts(member.audit_lastMinecraftMessage)}`);
-  } else {
-    lines.push("**Minecraft** — _not registered on website_");
-  }
+  lines.push(discordLinked ? `<@${member.discordId}>` : "❌ No Discord linked");
 
-  // Discord
-  if (discordLinked) {
-    lines.push(`**Discord** — Chat: ${ts(member.audit_lastDiscordMessage)} · Voice: ${ts(member.audit_lastDiscordVoice)}`);
-  } else {
-    lines.push("**Discord** — _not linked_");
-  }
+  lines.push(websiteLinked
+    ? `⛏️ Login ${ts(member.audit_lastMinecraftLogin)} · Chat ${ts(member.audit_lastMinecraftMessage)}`
+    : "⛏️ _Not registered on website_");
 
-  // Website
-  lines.push(`**Website** — Login: ${websiteLinked ? ts(member.audit_lastWebsiteLogin) : "_not registered_"}`);
+  lines.push(discordLinked
+    ? `💬 Chat ${ts(member.audit_lastDiscordMessage)} · 🔊 Voice ${ts(member.audit_lastDiscordVoice)}`
+    : "💬 _No Discord linked_");
+
+  lines.push(`🌐 Login ${websiteLinked ? ts(member.audit_lastWebsiteLogin) : "_not registered_"}`);
 
   return lines.join("\n");
 }
@@ -212,10 +202,7 @@ export async function runStaffAuditReport() {
     fieldCount++;
   }
 
-  const timezone = auditConfig.timezone || "UTC";
-  currentEmbed.setFooter({
-    text: `Total active staff: ${staffMembers.length} · Schedule: ${auditConfig.dayOfWeek || "Monday"} ${auditConfig.time || "12:00"} ${timezone}`,
-  });
+  currentEmbed.setFooter({ text: `${staffMembers.length} active staff members` });
   embeds.push(currentEmbed);
 
   const channel = await client.channels.fetch(channelId);

--- a/cron/staffAuditReportCron.js
+++ b/cron/staffAuditReportCron.js
@@ -169,7 +169,7 @@ function packIntoFields(sections) {
   return fields;
 }
 
-async function runStaffAuditReport() {
+export async function runStaffAuditReport() {
   // Check feature flag
   if (!features.staffAuditReport) {
     return;

--- a/cron/staffAuditReportCron.js
+++ b/cron/staffAuditReportCron.js
@@ -1,7 +1,7 @@
 import cron from "node-cron";
 import { Colors, EmbedBuilder } from "discord.js";
 import { createRequire } from "module";
-import db from "../controllers/databaseController.js";
+import db, { luckpermsDb } from "../controllers/databaseController.js";
 import { client } from "../controllers/discordController.js";
 
 const require = createRequire(import.meta.url);
@@ -86,12 +86,15 @@ function buildMemberField(member) {
 }
 
 async function fetchActiveStaff() {
-  return new Promise((resolve, reject) => {
+  // Step 1: fetch staff from main DB using the LP-backed views.
+  // LEFT JOIN users so LP members who haven't registered on the website
+  // still appear (userId/username will be NULL for them).
+  const rows = await new Promise((resolve, reject) => {
     db.query(
       `SELECT
         ur.uuid,
-        COALESCE(u.username, lp.username) AS username,
         u.userId,
+        u.username,
         u.discordId,
         u.audit_lastDiscordMessage,
         u.audit_lastDiscordVoice,
@@ -101,18 +104,39 @@ async function fetchActiveStaff() {
       FROM userRanks ur
       JOIN ranks r ON r.rankSlug = ur.rankSlug
       LEFT JOIN users u ON u.userId = ur.userId
-      LEFT JOIN cfcdev_luckperms.luckperms_players lp ON lp.uuid = ur.uuid
       WHERE r.isStaff = '1'
         AND ur.rankSlug != 'retired'
         AND (u.account_disabled IS NULL OR u.account_disabled = 0)
       GROUP BY ur.uuid
-      ORDER BY COALESCE(u.username, lp.username);`,
+      ORDER BY u.username;`,
       (error, results) => {
         if (error) return reject(error);
         resolve(results || []);
       }
     );
   });
+
+  // Step 2: for members not registered on the website (username IS NULL),
+  // look up their username from the LP database (separate server).
+  const unnamedUuids = rows.filter((r) => !r.username).map((r) => r.uuid);
+  if (unnamedUuids.length > 0) {
+    const lpNames = await new Promise((resolve, reject) => {
+      luckpermsDb.query(
+        `SELECT uuid, username FROM luckperms_players WHERE uuid IN (?)`,
+        [unnamedUuids],
+        (error, results) => {
+          if (error) return reject(error);
+          resolve(results || []);
+        }
+      );
+    });
+    const nameMap = Object.fromEntries(lpNames.map((r) => [r.uuid, r.username]));
+    for (const row of rows) {
+      if (!row.username) row.username = nameMap[row.uuid] ?? row.uuid;
+    }
+  }
+
+  return rows.sort((a, b) => (a.username ?? "").localeCompare(b.username ?? ""));
 }
 
 

--- a/cron/watchTwitchCron.js
+++ b/cron/watchTwitchCron.js
@@ -36,7 +36,6 @@ let tokenExpiresAt = 0;
 
 async function getTwitchAppToken(fetchFn) {
   if (cachedAppToken && Date.now() < tokenExpiresAt - 60_000) {
-    console.log("[WatchTwitch] Using cached app access token.");
     return cachedAppToken;
   }
 
@@ -60,7 +59,6 @@ async function getTwitchAppToken(fetchFn) {
     const data = await res.json();
     cachedAppToken = data.access_token;
     tokenExpiresAt = Date.now() + (data.expires_in || 3600) * 1000;
-    console.log(`[WatchTwitch] App access token obtained, expires in ${Math.round((tokenExpiresAt - Date.now()) / 60000)} minute(s).`);
     return cachedAppToken;
   } catch (err) {
     console.error("[WatchTwitch] Error fetching app access token:", err);
@@ -148,12 +146,6 @@ async function syncTwitchCreator(creator, stream) {
     const isCfc = Boolean(matchedRule);
     const isPublic = isCfc; // only CFC-tagged streams are publicly visible
 
-    console.log(
-      `[WatchTwitch] userId=${creator.user_id} (${creator.username}): ` +
-      `title="${(stream.title || "").substring(0, 60)}" | ` +
-      `tags=[${tags.join(", ")}] | cfc=${isCfc} | public=${isPublic} | matchedRule=${matchedRule || "none"}`
-    );
-
     const thumbnailUrl = stream.thumbnail_url
       ? stream.thumbnail_url.replace("{width}", "640").replace("{height}", "360")
       : null;
@@ -187,15 +179,11 @@ async function syncTwitchCreator(creator, stream) {
     // if messageId is null the send failed and we want the next run to retry.
     if (isPublic) {
       const alreadySent = await hasNotificationBeenSent("twitch", stream.id, "live");
-      if (alreadySent) {
-        console.log(`[WatchTwitch] userId=${creator.user_id}: live notification already sent for stream "${stream.id}" — skipping.`);
-      } else {
-        console.log(`[WatchTwitch] userId=${creator.user_id}: sending live notification for stream "${stream.id}".`);
+      if (!alreadySent) {
         const messageId = await sendLiveNotification(
           { ...contentItem, platform_display_name: creator.platform_display_name, username: creator.username }
         );
         if (messageId) {
-          console.log(`[WatchTwitch] userId=${creator.user_id}: notification sent (msgId=${messageId}).`);
           await recordNotification("twitch", stream.id, "live", messageId);
         } else {
           console.warn(`[WatchTwitch] userId=${creator.user_id}: notification failed for stream "${stream.id}" — will retry on next run.`);
@@ -204,21 +192,16 @@ async function syncTwitchCreator(creator, stream) {
 
       // In-game tip announcement (deduplicated independently of Discord)
       const ingameAlreadySent = await hasNotificationBeenSent("twitch", stream.id, "ingame_live");
-      if (ingameAlreadySent) {
-        console.log(`[WatchTwitch] userId=${creator.user_id}: in-game announcement already created for stream "${stream.id}" — skipping.`);
-      } else {
+      if (!ingameAlreadySent) {
         const creatorName = creator.platform_display_name || creator.username;
         const announcementBody = `Creator ${creatorName} is now live — watch now at craftingforchrist.net/watch`;
         try {
           await createInGameAnnouncement(announcementBody);
           await recordNotification("twitch", stream.id, "ingame_live", null);
-          console.log(`[WatchTwitch] userId=${creator.user_id}: in-game announcement created for stream "${stream.id}".`);
         } catch (err) {
           console.error(`[WatchTwitch] userId=${creator.user_id}: failed to create in-game announcement for stream "${stream.id}":`, err);
         }
       }
-    } else {
-      console.log(`[WatchTwitch] userId=${creator.user_id}: stream "${stream.id}" not CFC-tagged — not publicly visible, no notification.`);
     }
 
     await updateSyncStatus(creator.user_id, "twitch", { success: true });
@@ -246,7 +229,6 @@ const twitchSyncTask = cron.schedule("*/5 * * * *", async () => {
   }
 
   isTwitchSyncRunning = true;
-  console.log("[WatchTwitch] Sync started.");
 
   try {
     const { default: fetch } = await import("node-fetch");
@@ -257,18 +239,11 @@ const twitchSyncTask = cron.schedule("*/5 * * * *", async () => {
     }
 
     const creators = await getEligibleCreators("twitch");
-    if (creators.length === 0) {
-      console.log("[WatchTwitch] No eligible Twitch creators — nothing to sync.");
-      return;
-    }
-    console.log(`[WatchTwitch] Syncing ${creators.length} eligible creator(s).`);
+    if (creators.length === 0) return;
 
-    // Fetch each creator's stream once, pass it directly to syncTwitchCreator
-    // so we avoid fetching the same endpoint twice per creator.
     const liveStreamIds = [];
     for (const creator of creators) {
       const broadcasterId = creator.platform_account_id;
-      console.log(`[WatchTwitch] Checking creator: userId=${creator.user_id} (${creator.username}) broadcasterId=${broadcasterId}`);
       try {
         const streamRes = await fetch(
           `https://api.twitch.tv/helix/streams?user_id=${encodeURIComponent(broadcasterId)}`,
@@ -289,12 +264,7 @@ const twitchSyncTask = cron.schedule("*/5 * * * *", async () => {
         const streamData = await streamRes.json();
         const stream = streamData?.data?.[0] || null;
 
-        if (stream) {
-          console.log(`[WatchTwitch] userId=${creator.user_id} is LIVE: streamId=${stream.id}`);
-          liveStreamIds.push(stream.id);
-        } else {
-          console.log(`[WatchTwitch] userId=${creator.user_id} (${creator.username}) is offline.`);
-        }
+        if (stream) liveStreamIds.push(stream.id);
 
         await syncTwitchCreator(creator, stream);
       } catch (err) {
@@ -302,9 +272,7 @@ const twitchSyncTask = cron.schedule("*/5 * * * *", async () => {
       }
     }
 
-    console.log(`[WatchTwitch] Marking streams offline (excluding ${liveStreamIds.length} currently live).`);
     await markStreamsOffline("twitch", liveStreamIds);
-    console.log("[WatchTwitch] Sync complete.");
   } catch (err) {
     console.error("[WatchTwitch] Cron error:", err);
   } finally {

--- a/cron/watchYoutubeCron.js
+++ b/cron/watchYoutubeCron.js
@@ -113,8 +113,6 @@ async function resolveChannelId(rawId, apiKey, fetchFn) {
   // Already a proper channel ID
   if (rawId && rawId.startsWith("UC")) return rawId;
 
-  console.log(`[WatchYouTube] Channel ID "${rawId}" is not a UC... ID — attempting to resolve.`);
-
   // Try resolving via handle (@username) or legacy username
   const isHandle = rawId && rawId.startsWith("@");
   const param = isHandle
@@ -131,10 +129,7 @@ async function resolveChannelId(rawId, apiKey, fetchFn) {
     }
     const data = await res.json();
     const resolved = data?.items?.[0]?.id;
-    if (resolved) {
-      console.log(`[WatchYouTube] Resolved channel "${rawId}" -> "${resolved}"`);
-      return resolved;
-    }
+    if (resolved) return resolved;
     console.warn(`[WatchYouTube] Could not resolve channel "${rawId}" — no items returned. Using raw value.`);
   } catch (err) {
     console.error("[WatchYouTube] Channel ID resolution failed:", err);
@@ -166,7 +161,6 @@ async function getUploadsPlaylistId(channelId, apiKey, fetchFn) {
   const data = await res.json();
   const playlistId = data?.items?.[0]?.contentDetails?.relatedPlaylists?.uploads;
   if (playlistId) {
-    console.log(`[WatchYouTube] Uploads playlist for channel "${channelId}": ${playlistId}`);
     uploadsPlaylistCache.set(channelId, playlistId);
   } else {
     console.warn(`[WatchYouTube] No uploads playlist found for channel "${channelId}" — channel may be private or API response was empty.`);
@@ -210,21 +204,17 @@ async function syncYoutubeCreator(creator, apiKey, fetchFn) {
   }
 
   const channelId = await resolveChannelId(rawChannelId, apiKey, fetchFn);
-  console.log(`[WatchYouTube] userId=${creator.user_id} (${creator.username}): using channel "${channelId}"`);
   const liveIds = [];
 
   try {
     const searchItems = await fetchRecentChannelItems(channelId, apiKey, fetchFn);
     if (searchItems.length === 0) {
-      console.log(`[WatchYouTube] userId=${creator.user_id}: no recent uploads found.`);
       await updateSyncStatus(creator.user_id, "youtube", { success: true });
       return liveIds;
     }
-    console.log(`[WatchYouTube] userId=${creator.user_id}: ${searchItems.length} item(s) in uploads playlist.`);
 
     const videoIds = searchItems.map((i) => i.id?.videoId).filter(Boolean);
     const videoDetails = await fetchYoutubeVideoDetails(videoIds, apiKey, fetchFn);
-    console.log(`[WatchYouTube] userId=${creator.user_id}: fetched details for ${videoDetails.length}/${videoIds.length} video(s).`);
 
     for (const video of videoDetails) {
       const snippet = video.snippet || {};
@@ -237,10 +227,7 @@ async function syncYoutubeCreator(creator, apiKey, fetchFn) {
       const liveBroadcastContent = snippet.liveBroadcastContent; // "live", "upcoming", "none"
 
       // Skip if it's still upcoming
-      if (liveBroadcastContent === "upcoming") {
-        console.log(`[WatchYouTube] userId=${creator.user_id}: video "${video.id}" is upcoming — skipping.`);
-        continue;
-      }
+      if (liveBroadcastContent === "upcoming") continue;
 
       const matchedRule = matchesCfcFilter(
         "youtube",
@@ -256,13 +243,6 @@ async function syncYoutubeCreator(creator, apiKey, fetchFn) {
 
       // Only CFC-tagged content is publicly visible
       const isPublic = isCfc;
-
-      console.log(
-        `[WatchYouTube] userId=${creator.user_id}: video "${video.id}" | ` +
-        `title="${title.substring(0, 60)}" | ` +
-        `live=${isCurrentlyLive} | cfc=${isCfc} | public=${isPublic} | ` +
-        `matchedRule=${matchedRule || "none"} | tags=[${tags.join(", ")}]`
-      );
 
       const publishedAt = snippet.publishedAt ? new Date(snippet.publishedAt) : null;
       const startedAt = liveDetails?.actualStartTime ? new Date(liveDetails.actualStartTime) : null;
@@ -306,27 +286,20 @@ async function syncYoutubeCreator(creator, apiKey, fetchFn) {
 
       if (isCurrentlyLive) liveIds.push(video.id);
 
-      if (!isPublic) {
-        console.log(`[WatchYouTube] userId=${creator.user_id}: video "${video.id}" is not CFC-tagged — stored but not publicly visible, no notification.`);
-        continue;
-      }
+      if (!isPublic) continue;
 
       // Skip notifications for content that was already published before the
       // creator linked their account — prevents a flood of announcements on
       // first connection.  Currently-live streams are always announced since
       // they are actively happening right now.
       if (!isCurrentlyLive && publishedAt && creator.created_at && publishedAt < new Date(creator.created_at)) {
-        console.log(`[WatchYouTube] userId=${creator.user_id}: video "${video.id}" published before account connection (${publishedAt.toISOString()} < ${new Date(creator.created_at).toISOString()}) — skipping announcement.`);
         continue;
       }
 
       // Discord notifications
       const notifType = isCurrentlyLive ? "live" : "upload";
       const alreadySent = await hasNotificationBeenSent("youtube", video.id, notifType);
-      if (alreadySent) {
-        console.log(`[WatchYouTube] userId=${creator.user_id}: ${notifType} notification already sent for "${video.id}" — skipping.`);
-      } else {
-        console.log(`[WatchYouTube] userId=${creator.user_id}: sending ${notifType} notification for "${video.id}".`);
+      if (!alreadySent) {
         const messageId = await sendDiscordNotification(
           notifType,
           {
@@ -338,7 +311,6 @@ async function syncYoutubeCreator(creator, apiKey, fetchFn) {
         // If messageId is null the send failed; leave the record absent so
         // the next cron run can retry.
         if (messageId) {
-          console.log(`[WatchYouTube] userId=${creator.user_id}: notification sent for "${video.id}" (msgId=${messageId}).`);
           await recordNotification("youtube", video.id, notifType, messageId);
         } else {
           console.warn(`[WatchYouTube] userId=${creator.user_id}: notification failed for "${video.id}" — will retry on next run.`);
@@ -348,9 +320,7 @@ async function syncYoutubeCreator(creator, apiKey, fetchFn) {
       // In-game tip announcement (deduplicated independently of Discord)
       const ingameNotifType = `ingame_${notifType}`;
       const ingameAlreadySent = await hasNotificationBeenSent("youtube", video.id, ingameNotifType);
-      if (ingameAlreadySent) {
-        console.log(`[WatchYouTube] userId=${creator.user_id}: in-game announcement already created for "${video.id}" — skipping.`);
-      } else {
+      if (!ingameAlreadySent) {
         const creatorName = creator.platform_display_name || creator.username;
         const announcementBody = isCurrentlyLive
           ? `Creator ${creatorName} is now live — watch now at craftingforchrist.net/watch`
@@ -358,14 +328,12 @@ async function syncYoutubeCreator(creator, apiKey, fetchFn) {
         try {
           await createInGameAnnouncement(announcementBody);
           await recordNotification("youtube", video.id, ingameNotifType, null);
-          console.log(`[WatchYouTube] userId=${creator.user_id}: in-game announcement created for "${video.id}".`);
         } catch (err) {
           console.error(`[WatchYouTube] userId=${creator.user_id}: failed to create in-game announcement for "${video.id}":`, err);
         }
       }
     }
 
-    console.log(`[WatchYouTube] userId=${creator.user_id}: sync done. ${liveIds.length} live stream(s) currently active.`);
     await updateSyncStatus(creator.user_id, "youtube", { success: true });
   } catch (err) {
     console.error(`[WatchYouTube] Sync failed for user ${creator.user_id}:`, err);
@@ -394,16 +362,11 @@ const youtubeSyncTask = cron.schedule("*/15 * * * *", async () => {
   }
 
   isYoutubeSyncRunning = true;
-  console.log("[WatchYouTube] Sync started.");
 
   try {
     const { default: fetch } = await import("node-fetch");
     const creators = await getEligibleCreators("youtube");
-    if (creators.length === 0) {
-      console.log("[WatchYouTube] No eligible YouTube creators — nothing to sync.");
-      return;
-    }
-    console.log(`[WatchYouTube] Syncing ${creators.length} eligible creator(s).`);
+    if (creators.length === 0) return;
 
     const allLiveIds = [];
     for (const creator of creators) {
@@ -411,9 +374,7 @@ const youtubeSyncTask = cron.schedule("*/15 * * * *", async () => {
       allLiveIds.push(...liveIds);
     }
 
-    console.log(`[WatchYouTube] Marking streams offline (excluding ${allLiveIds.length} currently live).`);
     await markStreamsOffline("youtube", allLiveIds);
-    console.log("[WatchYouTube] Sync complete.");
   } catch (err) {
     console.error("[WatchYouTube] Cron error:", err);
   } finally {


### PR DESCRIPTION
## Summary
Refactored the staff audit report system to query LuckPerms directly for staff group membership instead of relying on the website database rank system. Added a new Discord slash command to manually trigger the report. Improved message delivery by using Discord client channels instead of webhooks, and simplified the embed formatting logic.

## Key Changes

### Staff Audit Report Cron (`cron/staffAuditReportCron.js`)
- **Data source migration**: Changed from querying website `userRanks`/`ranks` tables to querying LuckPerms directly for staff group membership via `staffGroups` config
- **Three-step data fetch**: 
  1. Query LuckPerms for UUIDs of users in configured staff groups
  2. Fetch usernames from LuckPerms player cache
  3. Merge with website audit data from main database
- **Simplified field formatting**: Replaced `buildMemberSection()` with `buildMemberField()` that uses inline emoji indicators and relative timestamps
- **Removed webhook delivery**: Changed from `WebhookClient` to using Discord client's `channel.send()` for direct message posting
- **Configuration changes**: Now uses `channelId` (instead of webhook URL) and requires `staffGroups` array (e.g., `["mod", "admin"]`)
- **Return value**: Function now returns status object with `sent`, `reason`, `staffCount`, and `embedCount` for better error reporting
- **Removed field packing logic**: Eliminated complex `packIntoFields()` function; each staff member now gets their own named field (max 25 per embed)

### New Staff Audit Report Command (`commands/staffauditreport.mjs`)
- Added `/staff-audit-report` slash command to manually trigger the audit report
- Requires linked Minecraft account and `zander.web.audit` permission node
- Returns ephemeral feedback with report status or error details
- Provides user-friendly error messages for missing configuration or permissions

### User Permissions Controller (`controllers/userController.js`)
- **UUID handling fix**: Changed LuckPerms queries to use raw UUID strings (VARCHAR with dashes) instead of `UNHEX()` conversion
- Added clarifying comments explaining LP's native UUID format
- Updated `luckperms_players` query to select UUID as-is without `HEX()` conversion
- Fixed UUID parameter passing to use `rawUuid` instead of `uuidHex` in permission queries

### Audit Controller (`controllers/auditController.js`)
- Added null checks in `updateAudit_lastMinecraftMessage()` and `updateAudit_lastWebsiteLogin()` to prevent errors when user not found
- Fixed control flow in `updateAudit_lastDiscordMessage()` to properly handle missing linked accounts

### Discord Controller (`controllers/discordController.js`)
- Added `ApplicationCommandRegistries` configuration to use `BulkOverwrite` behavior instead of per-command registration
- Reduces startup API calls from 20+ sequential requests to a single PUT call, preventing interaction token expiration issues

### Logging Cleanup
- Removed verbose debug logging from `watchYoutubeCron.js` and `watchTwitchCron.js` to reduce noise in production logs
- Kept warning and error messages for actual issues

## Notable Implementation Details
- Staff members are sorted alphabetically by username in the report
- Each staff member's activity is displayed in a single embed field with emoji indicators (⛏️ for Minecraft, 💬 for Discord, 🌐 for website)
- Timestamps use Discord's relative format (`<t:timestamp:R>`) for "time ago" display
- Configuration supports both flat `channelId` and legacy `delivery.channelId` for backwards compatibility
- The command is exported as a named export to allow both cron scheduling and manual triggering

https://claude.ai/code/session_01AaM2jADCPvHVG5JrrJ4QJD