### PR TITLE
Improve event filtering, Discord formatting, and template editor UX

### DIFF
--- a/api/routes/events.js
+++ b/api/routes/events.js
@@ -139,9 +139,11 @@ export default function eventsApiRoute(app, _config, _db, features, _lang) {
     try {
       const result = await getEvents({
         status: req.query.status || null,
+        statuses: req.query.statuses ? req.query.statuses.split(",").filter(Boolean) : null,
         eventType: req.query.eventType || null,
         search: req.query.search || null,
         templateId: req.query.templateId ? parseInt(req.query.templateId) : null,
+        hidePast: req.query.hidePast === "true" || req.query.hidePast === "1",
         page: Math.max(parseInt(req.query.page || "1"), 1),
         limit: Math.min(parseInt(req.query.limit || "50"), 200),
       });

--- a/routes/dashboard/events.js
+++ b/routes/dashboard/events.js
@@ -275,7 +275,7 @@ export default function dashboardEventsSiteRoute(app, fetch, config, db, feature
         features,
         req,
         mode: "create",
-        templateData: null,
+        tmpl: null,
         globalImage,
         announcementWeb,
       })
@@ -310,7 +310,7 @@ export default function dashboardEventsSiteRoute(app, fetch, config, db, feature
         features,
         req,
         mode: "edit",
-        templateData: apiData.data,
+        tmpl: apiData.data,
         globalImage,
         announcementWeb,
       })

--- a/routes/dashboard/events.js
+++ b/routes/dashboard/events.js
@@ -207,13 +207,23 @@ export default function dashboardEventsSiteRoute(app, fetch, config, db, feature
       return res.redirect("/dashboard/events/list");
     }
 
+    const ev = apiData.data;
+    const statusColors = {
+      draft: "secondary", pending_review: "warning", approved: "info",
+      published: "success", rejected: "danger", cancelled: "purple", archived: "dark",
+    };
+    const badgeClass = statusColors[ev.status] || "secondary";
+    const canEdit = ["draft", "rejected", "published"].includes(ev.status);
+
     res.header("content-type", "text/html; charset=utf-8").send(
       await app.view("dashboard/events/events-view", {
-        pageTitle: `Dashboard - ${apiData.data.title}`,
+        pageTitle: `Dashboard - ${ev.title}`,
         config,
         features,
         req,
-        eventData: apiData.data,
+        ev,
+        badgeClass,
+        canEdit,
         globalImage,
         announcementWeb,
       })

--- a/routes/dashboard/events.js
+++ b/routes/dashboard/events.js
@@ -143,6 +143,7 @@ export default function dashboardEventsSiteRoute(app, fetch, config, db, feature
         mode: "create",
         ev: {},
         isPublished: false,
+        apiEndpoint: "/api/events/create",
         templatesData,
         globalImage,
         announcementWeb,
@@ -174,6 +175,8 @@ export default function dashboardEventsSiteRoute(app, fetch, config, db, feature
 
     const ev = apiData.data;
 
+    const isPublished = ev.status === "published";
+
     res.header("content-type", "text/html; charset=utf-8").send(
       await app.view("dashboard/events/events-editor", {
         pageTitle: `Dashboard - Edit Event`,
@@ -182,7 +185,8 @@ export default function dashboardEventsSiteRoute(app, fetch, config, db, feature
         req,
         mode: "edit",
         ev,
-        isPublished: ev.status === "published",
+        isPublished,
+        apiEndpoint: isPublished ? "/api/events/update-published" : "/api/events/update",
         templatesData,
         globalImage,
         announcementWeb,

--- a/routes/dashboard/events.js
+++ b/routes/dashboard/events.js
@@ -58,9 +58,17 @@ export default function dashboardEventsSiteRoute(app, fetch, config, db, feature
 
     const statusFilter = req.query.status || "";
     const search = req.query.search || "";
+    const showPast = req.query.showPast === "1";
+
+    const DEFAULT_STATUSES = ["draft", "approved", "published"];
 
     let qs = "";
-    if (statusFilter) qs += `&status=${encodeURIComponent(statusFilter)}`;
+    if (statusFilter) {
+      qs += `&status=${encodeURIComponent(statusFilter)}`;
+    } else {
+      qs += `&statuses=${encodeURIComponent(DEFAULT_STATUSES.join(","))}`;
+    }
+    if (!showPast) qs += "&hidePast=1";
     if (search) qs += `&search=${encodeURIComponent(search)}`;
 
     const fetchURL = `${process.env.siteAddress}/api/events/get?limit=100${qs}`;
@@ -80,6 +88,7 @@ export default function dashboardEventsSiteRoute(app, fetch, config, db, feature
         apiData,
         statusFilter,
         search,
+        showPast,
         globalImage,
         announcementWeb,
       })

--- a/routes/dashboard/events.js
+++ b/routes/dashboard/events.js
@@ -141,7 +141,8 @@ export default function dashboardEventsSiteRoute(app, fetch, config, db, feature
         features,
         req,
         mode: "create",
-        eventData: null,
+        ev: {},
+        isPublished: false,
         templatesData,
         globalImage,
         announcementWeb,
@@ -171,6 +172,8 @@ export default function dashboardEventsSiteRoute(app, fetch, config, db, feature
       return res.redirect("/dashboard/events/list");
     }
 
+    const ev = apiData.data;
+
     res.header("content-type", "text/html; charset=utf-8").send(
       await app.view("dashboard/events/events-editor", {
         pageTitle: `Dashboard - Edit Event`,
@@ -178,7 +181,8 @@ export default function dashboardEventsSiteRoute(app, fetch, config, db, feature
         features,
         req,
         mode: "edit",
-        eventData: apiData.data,
+        ev,
+        isPublished: ev.status === "published",
         templatesData,
         globalImage,
         announcementWeb,
@@ -268,6 +272,8 @@ export default function dashboardEventsSiteRoute(app, fetch, config, db, feature
       getWebAnnouncement(),
     ]);
 
+    const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
     res.header("content-type", "text/html; charset=utf-8").send(
       await app.view("dashboard/events/events-template-editor", {
         pageTitle: "Dashboard - Create Event Template",
@@ -275,7 +281,9 @@ export default function dashboardEventsSiteRoute(app, fetch, config, db, feature
         features,
         req,
         mode: "create",
-        tmpl: null,
+        tmpl: {},
+        dayNames: DAY_NAMES,
+        recDays: [],
         globalImage,
         announcementWeb,
       })
@@ -303,6 +311,9 @@ export default function dashboardEventsSiteRoute(app, fetch, config, db, feature
       return res.redirect("/dashboard/events/templates");
     }
 
+    const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+    const tmpl = apiData.data;
+
     res.header("content-type", "text/html; charset=utf-8").send(
       await app.view("dashboard/events/events-template-editor", {
         pageTitle: "Dashboard - Edit Event Template",
@@ -310,7 +321,9 @@ export default function dashboardEventsSiteRoute(app, fetch, config, db, feature
         features,
         req,
         mode: "edit",
-        tmpl: apiData.data,
+        tmpl,
+        dayNames: DAY_NAMES,
+        recDays: (tmpl.recurrenceDays || []).map(Number),
         globalImage,
         announcementWeb,
       })

--- a/services/eventDiscordService.js
+++ b/services/eventDiscordService.js
@@ -7,21 +7,45 @@ import { client } from "../controllers/discordController.js";
 import { EmbedBuilder, GuildScheduledEventEntityType, GuildScheduledEventPrivacyLevel } from "discord.js";
 import { updateSyncStatus, logEventAudit } from "./eventService.js";
 
-/** Strip HTML tags from a string for plain-text Discord output. */
-function stripHtml(html) {
+/** Convert HTML from Summernote to Discord-compatible markdown. */
+function htmlToMarkdown(html) {
   if (!html) return "";
   return html
+    // Block-level: headings → bold line
+    .replace(/<h[1-3][^>]*>(.*?)<\/h[1-3]>/gi, (_, inner) => `**${inner.trim()}**\n`)
+    .replace(/<h[4-6][^>]*>(.*?)<\/h[4-6]>/gi, (_, inner) => `${inner.trim()}\n`)
+    // Inline formatting
+    .replace(/<strong[^>]*>(.*?)<\/strong>/gi, (_, inner) => `**${inner}**`)
+    .replace(/<b[^>]*>(.*?)<\/b>/gi, (_, inner) => `**${inner}**`)
+    .replace(/<em[^>]*>(.*?)<\/em>/gi, (_, inner) => `*${inner}*`)
+    .replace(/<i[^>]*>(.*?)<\/i>/gi, (_, inner) => `*${inner}*`)
+    .replace(/<u[^>]*>(.*?)<\/u>/gi, (_, inner) => `__${inner}__`)
+    .replace(/<s[^>]*>(.*?)<\/s>/gi, (_, inner) => `~~${inner}~~`)
+    .replace(/<del[^>]*>(.*?)<\/del>/gi, (_, inner) => `~~${inner}~~`)
+    .replace(/<code[^>]*>(.*?)<\/code>/gi, (_, inner) => `\`${inner}\``)
+    // Links
+    .replace(/<a[^>]+href="([^"]*)"[^>]*>(.*?)<\/a>/gi, (_, href, text) => {
+      const label = text.trim();
+      return label ? `[${label}](${href})` : href;
+    })
+    // Lists
+    .replace(/<li[^>]*>(.*?)<\/li>/gi, (_, inner) => `• ${inner.trim()}\n`)
+    .replace(/<\/[uo]l>/gi, "\n")
+    .replace(/<[uo]l[^>]*>/gi, "")
+    // Line breaks and paragraphs
     .replace(/<br\s*\/?>/gi, "\n")
     .replace(/<\/p>/gi, "\n\n")
-    .replace(/<\/li>/gi, "\n")
-    .replace(/<li>/gi, "• ")
+    .replace(/<\/div>/gi, "\n")
+    // Strip all remaining tags
     .replace(/<[^>]+>/g, "")
+    // Decode HTML entities
     .replace(/&amp;/g, "&")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&nbsp;/g, " ")
+    // Collapse excess blank lines
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 }
@@ -42,7 +66,7 @@ function buildEventEmbed(event) {
     );
 
   if (event.description) {
-    embed.setDescription(stripHtml(event.description).slice(0, 2048));
+    embed.setDescription(htmlToMarkdown(event.description).slice(0, 2048));
   }
 
   if (event.locationLabel) {
@@ -145,7 +169,7 @@ export async function createGuildScheduledEvent(event, guildId) {
     scheduledStartTime: new Date(event.startAt),
     scheduledEndTime: new Date(event.endAt),
     privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
-    description: event.description ? stripHtml(event.description).slice(0, 1000) : undefined,
+    description: event.description ? htmlToMarkdown(event.description).slice(0, 1000) : undefined,
     ...(isVoiceChannel
       ? {
           entityType: GuildScheduledEventEntityType.Voice,
@@ -203,7 +227,7 @@ export async function editGuildScheduledEvent(event, guildId, guildEventId) {
     name: event.title,
     scheduledStartTime: new Date(event.startAt),
     scheduledEndTime: new Date(event.endAt),
-    description: event.description ? stripHtml(event.description).slice(0, 1000) : undefined,
+    description: event.description ? htmlToMarkdown(event.description).slice(0, 1000) : undefined,
     ...(isVoiceChannel
       ? {
           entityType: GuildScheduledEventEntityType.Voice,

--- a/services/eventService.js
+++ b/services/eventService.js
@@ -92,18 +92,25 @@ export async function logEventAudit(eventId, actorId, actorName, action, details
  */
 export async function getEvents({
   status = null,
+  statuses = null,
   eventType = null,
   visibility = null,
   search = null,
   templateId = null,
   includeDeleted = false,
+  hidePast = false,
   page = 1,
   limit = 50,
 } = {}) {
   const where = {};
 
   if (!includeDeleted) where.deletedAt = null;
-  if (status) where.status = status;
+  if (statuses && statuses.length > 0) {
+    where.status = { in: statuses };
+  } else if (status) {
+    where.status = status;
+  }
+  if (hidePast) where.endAt = { gte: new Date() };
   if (eventType) where.eventType = eventType;
   if (visibility) where.visibility = visibility;
   if (templateId) where.templateId = templateId;

--- a/services/eventTemplateService.js
+++ b/services/eventTemplateService.js
@@ -317,24 +317,28 @@ export function computeNextGenerationDate(template, fromDate = null) {
         // The draft should be generated now (today), the event is on result
         // So generate trigger = result - advanceDays
         const generateOn = new Date(result.getTime() - advanceDays * 86400000);
+        // If generateOn is not strictly in the future, advance by one week
+        if (generateOn <= base) {
+          result.setUTCDate(result.getUTCDate() + 7);
+          return new Date(result.getTime() - advanceDays * 86400000);
+        }
         return generateOn;
       }
     }
   }
 
   if (template.recurrenceType === "daily") {
-    // Generate a draft for tomorrow's event today
-    const nextEventDate = new Date(base);
-    nextEventDate.setUTCDate(nextEventDate.getUTCDate() + 1);
-    nextEventDate.setUTCHours(0, 0, 0, 0);
-    const generateOn = new Date(nextEventDate.getTime() - advanceDays * 86400000);
-    return generateOn < base ? base : generateOn;
+    // Schedule the next generation for the following day at midnight UTC
+    const next = new Date(base);
+    next.setUTCDate(next.getUTCDate() + 1);
+    next.setUTCHours(0, 0, 0, 0);
+    return next;
   }
 
   if (template.recurrenceType === "custom" && template.recurrenceEveryDays) {
     const every = template.recurrenceEveryDays;
-    const last = template.lastGeneratedAt ? new Date(template.lastGeneratedAt) : base;
-    const next = new Date(last.getTime() + every * 86400000);
+    // Anchor the next generation to the current generation time
+    const next = new Date(base.getTime() + every * 86400000);
     return next;
   }
 

--- a/views/admin/_head.ejs
+++ b/views/admin/_head.ejs
@@ -13,6 +13,17 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
 
+  <!-- jQuery (required by Summernote) -->
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"
+          integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
+          crossorigin="anonymous"></script>
+
+  <!-- Summernote rich-text editor -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/summernote/0.8.20/summernote-bs5.min.css"
+        integrity="sha384-hqv27sxmxAI2L4eughLkUpjS75/Z3/hg9DOWIl0PJWE4B6GJqM2Kx72ZPoQzsUpF" crossorigin="anonymous">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/summernote/0.8.20/summernote-bs5.min.js"
+          integrity="sha384-VuY5PEOHfx/+RyPd+UmHCqDU8d9IM8bhIrXbbli+OpDD0A9G/YaovME4NwAzOyxt" crossorigin="anonymous"></script>
+
   <!-- Font Awesome 6 -->
   <link rel="stylesheet"
         href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css"

--- a/views/dashboard/events/events-list.ejs
+++ b/views/dashboard/events/events-list.ejs
@@ -25,19 +25,26 @@
       <%- include("../../admin/_notices.ejs") %>
 
             <!-- Filters -->
-            <form method="GET" action="/dashboard/events/list" class="row g-2 mb-3">
+            <form method="GET" action="/dashboard/events/list" class="row g-2 mb-3 align-items-center">
                 <div class="col-sm-4">
                     <select name="status" class="form-select form-select-sm" onchange="this.form.submit()">
-                        <option value="">All Statuses</option>
+                        <option value="">Active (Draft, Approved, Published)</option>
                         <% ['draft','pending_review','approved','published','rejected','cancelled','archived'].forEach(s => { %>
                             <option value="<%= s %>" <%= statusFilter === s ? 'selected' : '' %>><%= s.replace('_',' ').replace(/\b\w/g,c=>c.toUpperCase()) %></option>
                         <% }) %>
                     </select>
                 </div>
-                <div class="col-sm-6">
+                <div class="col-sm-5">
                     <div class="input-group input-group-sm">
                         <input type="text" name="search" class="form-control" placeholder="Search events…" value="<%= search %>">
                         <button class="btn btn-outline-secondary" type="submit"><i class="fas fa-search"></i></button>
+                    </div>
+                </div>
+                <div class="col-sm-3">
+                    <div class="form-check form-switch mb-0">
+                        <input class="form-check-input" type="checkbox" role="switch" id="showPastToggle"
+                            name="showPast" value="1" <%= showPast ? 'checked' : '' %> onchange="this.form.submit()">
+                        <label class="form-check-label small" for="showPastToggle">Show past events</label>
                     </div>
                 </div>
             </form>

--- a/views/dashboard/events/events-template-editor.ejs
+++ b/views/dashboard/events/events-template-editor.ejs
@@ -28,7 +28,11 @@
                         </div>
                         <div class="mb-3">
                             <label class="form-label fw-semibold">Default Description</label>
-                            <textarea class="form-control" name="description" id="tmplDescriptionEditor" rows="4"><%= tmpl.description || '' %></textarea>
+                            <%- include("../../partials/summerNoteEditor.ejs", {
+                                editorElementName: "tmplDescriptionEditor",
+                                editorPOSTElementName: "description",
+                                editorElementText: tmpl.description || ''
+                            }) %>
                         </div>
                         <div class="row g-3">
                             <div class="col-md-4">
@@ -707,10 +711,8 @@ document.getElementById('templateForm').addEventListener('submit', async (e) => 
     const fd = new FormData(form);
     const body = Object.fromEntries(fd.entries());
 
-    // Sync Summernote description
-    if (typeof $.fn.summernote !== 'undefined') {
-        body.description = $('#tmplDescriptionEditor').summernote('code');
-    }
+    // Description is synced by summerNoteEditor partial before submit
+    body.description = document.getElementById('tmplDescriptionEditor')?.value || '';
 
     // Convert local times back to UTC before submission
     const startLocalEl = document.getElementById('defaultStartTimeLocal');
@@ -860,25 +862,4 @@ function collectTemplateAnnouncements() {
 document.getElementById('addTemplateAnnouncementBtn').addEventListener('click', () => addTemplateAnnouncementRow());
 document.querySelectorAll('#templateAnnouncementsContainer .announcement-row').forEach(initAnnouncementRow);
 
-// Summernote description editor
-$(document).ready(function () {
-    $('#tmplDescriptionEditor').summernote({
-        height: 200,
-        toolbar: [
-            ['style', ['style']],
-            ['font', ['bold', 'italic', 'underline', 'strikethrough']],
-            ['para', ['ul', 'ol', 'paragraph']],
-            ['insert', ['link']],
-            ['view', ['fullscreen', 'codeview']],
-        ],
-        styleTags: [
-            { title: 'Paragraph', tag: 'p', className: '', value: 'p' },
-            { title: 'Heading 1', tag: 'h1', className: '', value: 'h1' },
-            { title: 'Heading 2', tag: 'h2', className: '', value: 'h2' },
-            { title: 'Heading 3', tag: 'h3', className: '', value: 'h3' },
-            { title: 'Heading 4', tag: 'h4', className: '', value: 'h4' },
-            { title: 'Quote', tag: 'blockquote', className: 'blockquote', value: 'blockquote' },
-        ],
-    });
-});
 </script>


### PR DESCRIPTION
## Summary
This PR enhances the events dashboard with better filtering capabilities, improves Discord message formatting for HTML content, refactors template editor to use a reusable rich-text editor component, and fixes event generation scheduling logic.

## Key Changes

### Events Dashboard & Filtering
- Added "Show past events" toggle to filter out past events by default
- Implemented default status filter showing only active events (draft, approved, published)
- Updated API to support multiple status filtering via `statuses` parameter
- Added `hidePast` query parameter to exclude events with `endAt` in the past

### Discord Integration
- Renamed `stripHtml()` to `htmlToMarkdown()` with enhanced HTML-to-Markdown conversion
- Added support for converting HTML formatting tags (headings, bold, italic, underline, strikethrough, code, links, lists) to Discord-compatible markdown
- Improved description handling in guild scheduled events with better formatting preservation

### Template Editor Refactoring
- Refactored template description editor to use reusable `summerNoteEditor.ejs` partial component
- Removed inline Summernote initialization code from template editor view
- Added `dayNames` and `recDays` data passed to template editor for better day selection UI
- Simplified form submission to use partial's synced editor value

### Event Generation Logic
- Fixed weekly recurrence generation to properly advance by one week if generation date is not in the future
- Simplified daily recurrence to schedule next generation for following day at midnight UTC
- Fixed custom recurrence to anchor next generation to current time rather than last generation time

### UI/UX Improvements
- Updated events list filter layout with better alignment
- Changed default status filter label from "All Statuses" to "Active (Draft, Approved, Published)"
- Added Summernote and jQuery dependencies to admin head template
- Renamed template data variables for consistency (`templateData` → `tmpl`, `eventData` → `ev`)
- Added `isPublished` flag and `apiEndpoint` routing for event editor based on publish status
- Added status badge styling and edit permission logic to event view page

## Implementation Details
- The `hidePast` filter uses `endAt >= now` to exclude completed events
- HTML to Markdown conversion handles nested tags and preserves link references
- Template editor now uses a shared partial for consistent rich-text editing across the application
- Event generation scheduling now properly handles edge cases where generation date would be in the past

https://claude.ai/code/session_018GEYacEQ4JRQYdS8KtuEZc