### PR TITLE
Add badge system with admin dashboard and profile display

### DIFF
--- a/admin/pageRegistry.js
+++ b/admin/pageRegistry.js
@@ -287,6 +287,18 @@ export const adminPages = [
     group: "System",
     sortOrder: 74,
   },
+
+  // ── Community — Badges ─────────────────────────────────────────────────────
+  {
+    slug: "badges",
+    title: "Badges",
+    menuTitle: "Badges",
+    icon: "fa-solid fa-award",
+    capability: "zander.web.badges",
+    path: "/dashboard/badges",
+    group: "Community",
+    sortOrder: 23,
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -341,6 +353,27 @@ export const adminSubPages = [
     parent: "forms",
     path: "/dashboard/forms/edit",
     capability: "zander.web.forms",
+  },
+  {
+    slug: "badges-create",
+    title: "Create Badge",
+    parent: "badges",
+    path: "/dashboard/badges/create",
+    capability: "zander.web.badges",
+  },
+  {
+    slug: "badges-edit",
+    title: "Edit Badge",
+    parent: "badges",
+    path: "/dashboard/badges/edit",
+    capability: "zander.web.badges",
+  },
+  {
+    slug: "badges-assign",
+    title: "Assign Badge",
+    parent: "badges",
+    path: "/dashboard/badges/assign",
+    capability: "zander.web.badges",
   },
 ];
 

--- a/api/routes/badges.js
+++ b/api/routes/badges.js
@@ -69,10 +69,10 @@ export default function badgeApiRoute(app, config, db, features, lang) {
   // POST /admin/badges — create badge
   // =========================================================================
   app.post("/admin/badges", async function (req, res) {
-    const { name, description, itemIcon, backgroundColor, textColor, luckpermsGroup } = req.body || {};
+    const { name, description, backgroundColor, textColor, luckpermsGroup } = req.body || {};
 
     try {
-      const badge = await createBadge({ name, description, itemIcon, backgroundColor, textColor, luckpermsGroup });
+      const badge = await createBadge({ name, description, backgroundColor, textColor, luckpermsGroup });
       return res.send({ success: true, message: "Badge created.", data: badge });
     } catch (error) {
       console.error("[badges] POST /admin/badges:", error);
@@ -87,13 +87,13 @@ export default function badgeApiRoute(app, config, db, features, lang) {
     const id = parseInt(req.params.id, 10);
     if (!id) return res.send({ success: false, message: "Invalid badge id." });
 
-    const { name, description, itemIcon, backgroundColor, textColor, luckpermsGroup } = req.body || {};
+    const { name, description, backgroundColor, textColor, luckpermsGroup } = req.body || {};
 
     try {
       const existing = await getBadgeById(id);
       if (!existing) return res.send({ success: false, message: "Badge not found." });
 
-      const badge = await updateBadge(id, { name, description, itemIcon, backgroundColor, textColor, luckpermsGroup });
+      const badge = await updateBadge(id, { name, description, backgroundColor, textColor, luckpermsGroup });
       return res.send({ success: true, message: "Badge updated.", data: badge });
     } catch (error) {
       console.error("[badges] PUT /admin/badges/:id:", error);

--- a/api/routes/badges.js
+++ b/api/routes/badges.js
@@ -69,10 +69,10 @@ export default function badgeApiRoute(app, config, db, features, lang) {
   // POST /admin/badges — create badge
   // =========================================================================
   app.post("/admin/badges", async function (req, res) {
-    const { name, description, itemIcon, backgroundColor, luckpermsGroup } = req.body || {};
+    const { name, description, itemIcon, backgroundColor, textColor, luckpermsGroup } = req.body || {};
 
     try {
-      const badge = await createBadge({ name, description, itemIcon, backgroundColor, luckpermsGroup });
+      const badge = await createBadge({ name, description, itemIcon, backgroundColor, textColor, luckpermsGroup });
       return res.send({ success: true, message: "Badge created.", data: badge });
     } catch (error) {
       console.error("[badges] POST /admin/badges:", error);
@@ -87,13 +87,13 @@ export default function badgeApiRoute(app, config, db, features, lang) {
     const id = parseInt(req.params.id, 10);
     if (!id) return res.send({ success: false, message: "Invalid badge id." });
 
-    const { name, description, itemIcon, backgroundColor, luckpermsGroup } = req.body || {};
+    const { name, description, itemIcon, backgroundColor, textColor, luckpermsGroup } = req.body || {};
 
     try {
       const existing = await getBadgeById(id);
       if (!existing) return res.send({ success: false, message: "Badge not found." });
 
-      const badge = await updateBadge(id, { name, description, itemIcon, backgroundColor, luckpermsGroup });
+      const badge = await updateBadge(id, { name, description, itemIcon, backgroundColor, textColor, luckpermsGroup });
       return res.send({ success: true, message: "Badge updated.", data: badge });
     } catch (error) {
       console.error("[badges] PUT /admin/badges/:id:", error);

--- a/api/routes/badges.js
+++ b/api/routes/badges.js
@@ -1,0 +1,191 @@
+/**
+ * api/routes/badges.js
+ *
+ * Badge system API routes.
+ *
+ * Public (token required — all API routes use token auth):
+ *   GET  /api/badges/user/:username    — badges for a profile page
+ *
+ * Admin (token required):
+ *   GET    /admin/badges                     — list all badges
+ *   POST   /admin/badges                     — create badge
+ *   PUT    /admin/badges/:id                 — update badge
+ *   DELETE /admin/badges/:id                 — delete badge
+ *   POST   /admin/badges/:id/duplicate       — duplicate badge
+ *   GET    /admin/badges/user/:userId        — badges for a user (by userId)
+ *   POST   /admin/badges/:id/assign/:userId  — assign badge to user
+ *   DELETE /admin/badges/:id/assign/:userId  — remove badge from user
+ */
+
+import {
+  getAllBadges,
+  getBadgeById,
+  createBadge,
+  updateBadge,
+  deleteBadge,
+  duplicateBadge,
+  getBadgesForUser,
+  assignBadgeToUser,
+  removeBadgeFromUser,
+} from "../../controllers/badgeController.js";
+import { UserGetter } from "../../controllers/userController.js";
+
+export default function badgeApiRoute(app, config, db, features, lang) {
+
+  // =========================================================================
+  // GET /api/badges/user/:username — public-facing profile badges
+  // =========================================================================
+  app.get("/api/badges/user/:username", async function (req, res) {
+    const { username } = req.params;
+    if (!username) return res.send({ success: false, message: "Username required." });
+
+    try {
+      const getter = new UserGetter();
+      const user = await getter.byUsername(username);
+      if (!user) return res.send({ success: false, message: "User not found." });
+
+      const badges = await getBadgesForUser(user.userId);
+      return res.send({ success: true, data: badges });
+    } catch (error) {
+      console.error("[badges] GET /api/badges/user/:username:", error);
+      if (!res.sent) return res.status(500).send({ success: false, message: `${error}` });
+    }
+  });
+
+  // =========================================================================
+  // GET /admin/badges — list all badges
+  // =========================================================================
+  app.get("/admin/badges", async function (req, res) {
+    try {
+      const badges = await getAllBadges();
+      return res.send({ success: true, data: badges });
+    } catch (error) {
+      console.error("[badges] GET /admin/badges:", error);
+      if (!res.sent) return res.status(500).send({ success: false, message: `${error}` });
+    }
+  });
+
+  // =========================================================================
+  // POST /admin/badges — create badge
+  // =========================================================================
+  app.post("/admin/badges", async function (req, res) {
+    const { name, description, itemIcon, backgroundColor, luckpermsGroup } = req.body || {};
+
+    try {
+      const badge = await createBadge({ name, description, itemIcon, backgroundColor, luckpermsGroup });
+      return res.send({ success: true, message: "Badge created.", data: badge });
+    } catch (error) {
+      console.error("[badges] POST /admin/badges:", error);
+      if (!res.sent) return res.status(400).send({ success: false, message: `${error.message || error}` });
+    }
+  });
+
+  // =========================================================================
+  // PUT /admin/badges/:id — update badge
+  // =========================================================================
+  app.put("/admin/badges/:id", async function (req, res) {
+    const id = parseInt(req.params.id, 10);
+    if (!id) return res.send({ success: false, message: "Invalid badge id." });
+
+    const { name, description, itemIcon, backgroundColor, luckpermsGroup } = req.body || {};
+
+    try {
+      const existing = await getBadgeById(id);
+      if (!existing) return res.send({ success: false, message: "Badge not found." });
+
+      const badge = await updateBadge(id, { name, description, itemIcon, backgroundColor, luckpermsGroup });
+      return res.send({ success: true, message: "Badge updated.", data: badge });
+    } catch (error) {
+      console.error("[badges] PUT /admin/badges/:id:", error);
+      if (!res.sent) return res.status(400).send({ success: false, message: `${error.message || error}` });
+    }
+  });
+
+  // =========================================================================
+  // DELETE /admin/badges/:id — delete badge
+  // =========================================================================
+  app.delete("/admin/badges/:id", async function (req, res) {
+    const id = parseInt(req.params.id, 10);
+    if (!id) return res.send({ success: false, message: "Invalid badge id." });
+
+    try {
+      const existing = await getBadgeById(id);
+      if (!existing) return res.send({ success: false, message: "Badge not found." });
+
+      await deleteBadge(id);
+      return res.send({ success: true, message: "Badge deleted." });
+    } catch (error) {
+      console.error("[badges] DELETE /admin/badges/:id:", error);
+      if (!res.sent) return res.status(500).send({ success: false, message: `${error}` });
+    }
+  });
+
+  // =========================================================================
+  // POST /admin/badges/:id/duplicate — duplicate badge
+  // =========================================================================
+  app.post("/admin/badges/:id/duplicate", async function (req, res) {
+    const id = parseInt(req.params.id, 10);
+    if (!id) return res.send({ success: false, message: "Invalid badge id." });
+
+    try {
+      const badge = await duplicateBadge(id);
+      return res.send({ success: true, message: "Badge duplicated.", data: badge });
+    } catch (error) {
+      console.error("[badges] POST /admin/badges/:id/duplicate:", error);
+      if (!res.sent) return res.status(500).send({ success: false, message: `${error.message || error}` });
+    }
+  });
+
+  // =========================================================================
+  // GET /admin/badges/user/:userId — all badges for a specific user (by userId)
+  // =========================================================================
+  app.get("/admin/badges/user/:userId", async function (req, res) {
+    const userId = parseInt(req.params.userId, 10);
+    if (!userId) return res.send({ success: false, message: "Invalid userId." });
+
+    try {
+      const badges = await getBadgesForUser(userId);
+      return res.send({ success: true, data: badges });
+    } catch (error) {
+      console.error("[badges] GET /admin/badges/user/:userId:", error);
+      if (!res.sent) return res.status(500).send({ success: false, message: `${error}` });
+    }
+  });
+
+  // =========================================================================
+  // POST /admin/badges/:id/assign/:userId — assign badge to user
+  // =========================================================================
+  app.post("/admin/badges/:id/assign/:userId", async function (req, res) {
+    const badgeId = parseInt(req.params.id, 10);
+    const userId = parseInt(req.params.userId, 10);
+    if (!badgeId || !userId) return res.send({ success: false, message: "Invalid badge or user id." });
+
+    try {
+      const existing = await getBadgeById(badgeId);
+      if (!existing) return res.send({ success: false, message: "Badge not found." });
+
+      await assignBadgeToUser(userId, badgeId);
+      return res.send({ success: true, message: "Badge assigned." });
+    } catch (error) {
+      console.error("[badges] POST /admin/badges/:id/assign/:userId:", error);
+      if (!res.sent) return res.status(500).send({ success: false, message: `${error}` });
+    }
+  });
+
+  // =========================================================================
+  // DELETE /admin/badges/:id/assign/:userId — remove badge from user
+  // =========================================================================
+  app.delete("/admin/badges/:id/assign/:userId", async function (req, res) {
+    const badgeId = parseInt(req.params.id, 10);
+    const userId = parseInt(req.params.userId, 10);
+    if (!badgeId || !userId) return res.send({ success: false, message: "Invalid badge or user id." });
+
+    try {
+      await removeBadgeFromUser(userId, badgeId);
+      return res.send({ success: true, message: "Badge removed from user." });
+    } catch (error) {
+      console.error("[badges] DELETE /admin/badges/:id/assign/:userId:", error);
+      if (!res.sent) return res.status(500).send({ success: false, message: `${error}` });
+    }
+  });
+}

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -20,6 +20,7 @@ import voteApiRoute from "./vote.js";
 import commandBridgeApiRoute from "./commandBridge.js";
 import eventsApiRoute from "./events.js";
 import uploadApiRoute from "./upload.js";
+import badgeApiRoute from "./badges.js";
 
 export default (app, client, moment, config, db, features, lang) => {
   announcementApiRoute(app, config, db, features, lang);
@@ -44,5 +45,6 @@ export default (app, client, moment, config, db, features, lang) => {
   commandBridgeApiRoute(app, config, db, features, lang);
   eventsApiRoute(app, config, db, features, lang);
   uploadApiRoute(app, config, db, features, lang);
+  badgeApiRoute(app, config, db, features, lang);
 
 };

--- a/api/routes/ranks.js
+++ b/api/routes/ranks.js
@@ -11,6 +11,11 @@ const LUCKPERMS_PLAYERS_TABLE = "luckperms_players";
 const LUCKPERMS_GROUP_PERMISSIONS_TABLE = "luckperms_group_permissions";
 const LUCKPERMS_USER_PERMISSIONS_TABLE = "luckperms_user_permissions";
 
+function stripUUID(uuid) {
+  if (!uuid) return null;
+  return String(uuid).replace(/-/g, '').toLowerCase();
+}
+
 function parseBoolean(value) {
   if (value === null || value === undefined) return null;
   if (typeof value === "boolean") return value;
@@ -122,10 +127,14 @@ export default function rankApiRoute(app, config, db, features, lang) {
       return null;
     }
 
+    // Normalise to 32-char hex (no dashes) so it matches the userRanks
+    // cross-DB view which stores uuid as LOWER(HEX(lp_binary_uuid)).
+    const uuidHex = luckPermsUser?.uuid ?? stripUUID(webUser?.uuid) ?? null;
+
     return {
       userId: webUser?.userId ?? null,
       username: webUser?.username || luckPermsUser?.username || trimmedUsername,
-      uuid: webUser?.uuid || luckPermsUser?.uuid || null,
+      uuid: uuidHex,
     };
   }
 
@@ -512,7 +521,7 @@ export default function rankApiRoute(app, config, db, features, lang) {
 
       const [existing] = await queryLuckPermsDb(
         `SELECT uuid FROM ${LUCKPERMS_USER_PERMISSIONS_TABLE}
-          WHERE uuid = ? AND permission = ? AND value = 1 LIMIT 1`,
+          WHERE uuid = UNHEX(?) AND permission = ? AND value = 1 LIMIT 1`,
         [player.uuid, `group.${rankSlug}`]
       );
 
@@ -526,13 +535,13 @@ export default function rankApiRoute(app, config, db, features, lang) {
       await queryLuckPermsDb(
         `INSERT INTO ${LUCKPERMS_USER_PERMISSIONS_TABLE}
           (uuid, permission, value, server, world, expiry, contexts)
-        VALUES (?, ?, 1, 'global', 'global', 0, '[]')`,
+        VALUES (UNHEX(?), ?, 1, 'global', 'global', 0, '[]')`,
         [player.uuid, `group.${rankSlug}`]
       );
 
       await queryLuckPermsDb(
         `DELETE FROM ${LUCKPERMS_USER_PERMISSIONS_TABLE}
-          WHERE uuid = ?
+          WHERE uuid = UNHEX(?)
             AND permission LIKE CONCAT('meta.group.', ?, '.title.%')`,
         [player.uuid, rankSlug]
       );
@@ -541,7 +550,7 @@ export default function rankApiRoute(app, config, db, features, lang) {
         await queryLuckPermsDb(
           `INSERT INTO ${LUCKPERMS_USER_PERMISSIONS_TABLE}
             (uuid, permission, value, server, world, expiry, contexts)
-          VALUES (?, ?, 1, 'global', 'global', 0, '[]')`,
+          VALUES (UNHEX(?), ?, 1, 'global', 'global', 0, '[]')`,
           [player.uuid, `meta.group.${rankSlug}.title.${title.substring(0, 64)}`]
         );
       }
@@ -579,13 +588,13 @@ export default function rankApiRoute(app, config, db, features, lang) {
 
       const result = await queryLuckPermsDb(
         `DELETE FROM ${LUCKPERMS_USER_PERMISSIONS_TABLE}
-          WHERE uuid = ? AND permission = ?`,
+          WHERE uuid = UNHEX(?) AND permission = ?`,
         [player.uuid, `group.${rankSlug}`]
       );
 
       await queryLuckPermsDb(
         `DELETE FROM ${LUCKPERMS_USER_PERMISSIONS_TABLE}
-          WHERE uuid = ?
+          WHERE uuid = UNHEX(?)
             AND permission LIKE CONCAT('meta.group.', ?, '.title.%')`,
         [player.uuid, rankSlug]
       );

--- a/app.js
+++ b/app.js
@@ -51,6 +51,7 @@ import("./cron/unverifiedReminderCron.js");
 // eventAnnouncementCron removed — event announcements now use scheduledDiscordMessages via schedulerCron
 import("./cron/eventTemplateCron.js");
 import("./cron/announcementExpiryCron.js");
+import("./cron/badgeLuckpermsSyncCron.js");
 
 //
 // Website Related

--- a/commands/profile.mjs
+++ b/commands/profile.mjs
@@ -140,6 +140,31 @@ export class ProfileCommand extends Command {
           }
         );
 
+      // Fetch and display badges
+      try {
+        const badgeRes = await fetch(
+          `${process.env.siteAddress}/api/badges/user/${encodeURIComponent(apiData.data.profileData.username)}`,
+          { headers: { "x-access-token": process.env.apiKey } }
+        );
+        const badgeData = await badgeRes.json();
+
+        if (badgeData.success && badgeData.data && badgeData.data.length > 0) {
+          const MAX_SHOWN = 5;
+          const badges = badgeData.data;
+          const shown = badges.slice(0, MAX_SHOWN);
+          const extra = badges.length - shown.length;
+
+          const badgeLines = shown.map((b) => `🏅 ${b.name}`).join("\n");
+          const badgeValue = extra > 0
+            ? `${badgeLines}\n*+${extra} more — [view profile](${process.env.siteAddress}/profile/${apiData.data.profileData.username})*`
+            : badgeLines;
+
+          embed.addFields({ name: "Badges", value: badgeValue, inline: false });
+        }
+      } catch (_) {
+        // badges unavailable — profile still renders without them
+      }
+
       interaction.reply({
         embeds: [embed],
         empheral: false,

--- a/controllers/badgeController.js
+++ b/controllers/badgeController.js
@@ -28,8 +28,8 @@ export async function getBadgeByLuckpermsGroup(luckpermsGroup) {
   return prisma.badges.findFirst({ where: { luckpermsGroup } });
 }
 
-export async function createBadge({ name, description, itemIcon, backgroundColor, luckpermsGroup }) {
-  validateBadgeInput({ name, itemIcon, backgroundColor });
+export async function createBadge({ name, description, itemIcon, backgroundColor, textColor, luckpermsGroup }) {
+  validateBadgeInput({ name, itemIcon, backgroundColor, textColor });
 
   return prisma.badges.create({
     data: {
@@ -37,13 +37,14 @@ export async function createBadge({ name, description, itemIcon, backgroundColor
       description: description?.trim() || null,
       itemIcon: itemIcon.trim().toLowerCase(),
       backgroundColor: normaliseHex(backgroundColor),
+      textColor: normaliseHex(textColor || "#ffffff"),
       luckpermsGroup: luckpermsGroup?.trim() || null,
     },
   });
 }
 
-export async function updateBadge(badgeId, { name, description, itemIcon, backgroundColor, luckpermsGroup }) {
-  validateBadgeInput({ name, itemIcon, backgroundColor });
+export async function updateBadge(badgeId, { name, description, itemIcon, backgroundColor, textColor, luckpermsGroup }) {
+  validateBadgeInput({ name, itemIcon, backgroundColor, textColor });
 
   return prisma.badges.update({
     where: { badgeId },
@@ -52,6 +53,7 @@ export async function updateBadge(badgeId, { name, description, itemIcon, backgr
       description: description?.trim() || null,
       itemIcon: itemIcon.trim().toLowerCase(),
       backgroundColor: normaliseHex(backgroundColor),
+      textColor: normaliseHex(textColor || "#ffffff"),
       luckpermsGroup: luckpermsGroup?.trim() || null,
     },
   });
@@ -152,13 +154,16 @@ export async function getUsersWithBadge(badgeId) {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function validateBadgeInput({ name, itemIcon, backgroundColor }) {
+function validateBadgeInput({ name, itemIcon, backgroundColor, textColor }) {
   if (!name || name.trim().length === 0) throw new Error("Badge name is required.");
   if (name.trim().length > 100) throw new Error("Badge name must be 100 characters or fewer.");
   if (!itemIcon || itemIcon.trim().length === 0) throw new Error("Item icon is required.");
   if (itemIcon.trim().length > 100) throw new Error("Item icon must be 100 characters or fewer.");
   if (!backgroundColor || !/^#[0-9A-Fa-f]{6}$/.test(backgroundColor.trim())) {
     throw new Error("Background colour must be a valid hex colour (e.g. #1a1a2e).");
+  }
+  if (textColor && !/^#[0-9A-Fa-f]{6}$/.test(textColor.trim())) {
+    throw new Error("Text colour must be a valid hex colour (e.g. #ffffff).");
   }
 }
 

--- a/controllers/badgeController.js
+++ b/controllers/badgeController.js
@@ -28,14 +28,13 @@ export async function getBadgeByLuckpermsGroup(luckpermsGroup) {
   return prisma.badges.findFirst({ where: { luckpermsGroup } });
 }
 
-export async function createBadge({ name, description, itemIcon, backgroundColor, textColor, luckpermsGroup }) {
-  validateBadgeInput({ name, itemIcon, backgroundColor, textColor });
+export async function createBadge({ name, description, backgroundColor, textColor, luckpermsGroup }) {
+  validateBadgeInput({ name, backgroundColor, textColor });
 
   return prisma.badges.create({
     data: {
       name: name.trim(),
       description: description?.trim() || null,
-      itemIcon: itemIcon.trim().toLowerCase(),
       backgroundColor: normaliseHex(backgroundColor),
       textColor: normaliseHex(textColor || "#ffffff"),
       luckpermsGroup: luckpermsGroup?.trim() || null,
@@ -43,15 +42,14 @@ export async function createBadge({ name, description, itemIcon, backgroundColor
   });
 }
 
-export async function updateBadge(badgeId, { name, description, itemIcon, backgroundColor, textColor, luckpermsGroup }) {
-  validateBadgeInput({ name, itemIcon, backgroundColor, textColor });
+export async function updateBadge(badgeId, { name, description, backgroundColor, textColor, luckpermsGroup }) {
+  validateBadgeInput({ name, backgroundColor, textColor });
 
   return prisma.badges.update({
     where: { badgeId },
     data: {
       name: name.trim(),
       description: description?.trim() || null,
-      itemIcon: itemIcon.trim().toLowerCase(),
       backgroundColor: normaliseHex(backgroundColor),
       textColor: normaliseHex(textColor || "#ffffff"),
       luckpermsGroup: luckpermsGroup?.trim() || null,
@@ -71,9 +69,9 @@ export async function duplicateBadge(badgeId) {
     data: {
       name: `${source.name} (Copy)`,
       description: source.description,
-      itemIcon: source.itemIcon,
       backgroundColor: source.backgroundColor,
-      luckpermsGroup: null, // don't copy LP link to avoid duplicate auto-assignment
+      textColor: source.textColor,
+      luckpermsGroup: null,
     },
   });
 }
@@ -154,11 +152,9 @@ export async function getUsersWithBadge(badgeId) {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function validateBadgeInput({ name, itemIcon, backgroundColor, textColor }) {
+function validateBadgeInput({ name, backgroundColor, textColor }) {
   if (!name || name.trim().length === 0) throw new Error("Badge name is required.");
   if (name.trim().length > 100) throw new Error("Badge name must be 100 characters or fewer.");
-  if (!itemIcon || itemIcon.trim().length === 0) throw new Error("Item icon is required.");
-  if (itemIcon.trim().length > 100) throw new Error("Item icon must be 100 characters or fewer.");
   if (!backgroundColor || !/^#[0-9A-Fa-f]{6}$/.test(backgroundColor.trim())) {
     throw new Error("Background colour must be a valid hex colour (e.g. #1a1a2e).");
   }

--- a/controllers/badgeController.js
+++ b/controllers/badgeController.js
@@ -1,0 +1,167 @@
+/**
+ * controllers/badgeController.js
+ *
+ * CRUD and assignment logic for the Badge system.
+ * Uses the Prisma client for all database operations.
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+// ---------------------------------------------------------------------------
+// Badge CRUD
+// ---------------------------------------------------------------------------
+
+export async function getAllBadges() {
+  return prisma.badges.findMany({
+    orderBy: { createdAt: "asc" },
+  });
+}
+
+export async function getBadgeById(badgeId) {
+  return prisma.badges.findUnique({ where: { badgeId } });
+}
+
+export async function getBadgeByLuckpermsGroup(luckpermsGroup) {
+  if (!luckpermsGroup) return null;
+  return prisma.badges.findFirst({ where: { luckpermsGroup } });
+}
+
+export async function createBadge({ name, description, itemIcon, backgroundColor, luckpermsGroup }) {
+  validateBadgeInput({ name, itemIcon, backgroundColor });
+
+  return prisma.badges.create({
+    data: {
+      name: name.trim(),
+      description: description?.trim() || null,
+      itemIcon: itemIcon.trim().toLowerCase(),
+      backgroundColor: normaliseHex(backgroundColor),
+      luckpermsGroup: luckpermsGroup?.trim() || null,
+    },
+  });
+}
+
+export async function updateBadge(badgeId, { name, description, itemIcon, backgroundColor, luckpermsGroup }) {
+  validateBadgeInput({ name, itemIcon, backgroundColor });
+
+  return prisma.badges.update({
+    where: { badgeId },
+    data: {
+      name: name.trim(),
+      description: description?.trim() || null,
+      itemIcon: itemIcon.trim().toLowerCase(),
+      backgroundColor: normaliseHex(backgroundColor),
+      luckpermsGroup: luckpermsGroup?.trim() || null,
+    },
+  });
+}
+
+export async function deleteBadge(badgeId) {
+  return prisma.badges.delete({ where: { badgeId } });
+}
+
+export async function duplicateBadge(badgeId) {
+  const source = await getBadgeById(badgeId);
+  if (!source) throw new Error("Badge not found.");
+
+  return prisma.badges.create({
+    data: {
+      name: `${source.name} (Copy)`,
+      description: source.description,
+      itemIcon: source.itemIcon,
+      backgroundColor: source.backgroundColor,
+      luckpermsGroup: null, // don't copy LP link to avoid duplicate auto-assignment
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// User badge assignment
+// ---------------------------------------------------------------------------
+
+/**
+ * Get all badges for a user (including badge details).
+ */
+export async function getBadgesForUser(userId) {
+  const rows = await prisma.user_badges.findMany({
+    where: { userId },
+    include: { badge: true },
+    orderBy: { earnedAt: "asc" },
+  });
+  return rows.map((r) => ({ ...r.badge, earnedAt: r.earnedAt, isManual: r.isManual }));
+}
+
+/**
+ * Assign a badge to a user manually.
+ */
+export async function assignBadgeToUser(userId, badgeId) {
+  return prisma.user_badges.upsert({
+    where: { userId_badgeId: { userId, badgeId } },
+    create: { userId, badgeId, isManual: true },
+    update: { isManual: true }, // upgrade to manual if it was auto
+  });
+}
+
+/**
+ * Remove a badge from a user (manual operation; respects isManual flag handled at controller level).
+ */
+export async function removeBadgeFromUser(userId, badgeId) {
+  return prisma.user_badges.deleteMany({ where: { userId, badgeId } });
+}
+
+/**
+ * Sync a badge linked to a LuckPerms group: grant to users who have the group,
+ * remove from users who no longer have it (unless isManual=true).
+ *
+ * @param {number}   badgeId
+ * @param {number[]} userIdsWithGroup  – all userId values currently having the LP group
+ */
+export async function syncLuckpermsBadge(badgeId, userIdsWithGroup) {
+  // Grant badge (upsert) for all users who currently have the group
+  for (const userId of userIdsWithGroup) {
+    await prisma.user_badges.upsert({
+      where: { userId_badgeId: { userId, badgeId } },
+      create: { userId, badgeId, isManual: false },
+      update: {}, // don't overwrite isManual if already set
+    });
+  }
+
+  // Remove non-manual assignments for users no longer in the group
+  await prisma.user_badges.deleteMany({
+    where: {
+      badgeId,
+      isManual: false,
+      userId: { notIn: userIdsWithGroup.length > 0 ? userIdsWithGroup : [-1] },
+    },
+  });
+}
+
+/**
+ * Get all users that currently hold a given badge (for sync diff).
+ */
+export async function getUsersWithBadge(badgeId) {
+  const rows = await prisma.user_badges.findMany({
+    where: { badgeId },
+    select: { userId: true, isManual: true },
+  });
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function validateBadgeInput({ name, itemIcon, backgroundColor }) {
+  if (!name || name.trim().length === 0) throw new Error("Badge name is required.");
+  if (name.trim().length > 100) throw new Error("Badge name must be 100 characters or fewer.");
+  if (!itemIcon || itemIcon.trim().length === 0) throw new Error("Item icon is required.");
+  if (itemIcon.trim().length > 100) throw new Error("Item icon must be 100 characters or fewer.");
+  if (!backgroundColor || !/^#[0-9A-Fa-f]{6}$/.test(backgroundColor.trim())) {
+    throw new Error("Background colour must be a valid hex colour (e.g. #1a1a2e).");
+  }
+}
+
+function normaliseHex(hex) {
+  return hex.trim().toLowerCase();
+}

--- a/cron/badgeLuckpermsSyncCron.js
+++ b/cron/badgeLuckpermsSyncCron.js
@@ -1,0 +1,93 @@
+/**
+ * cron/badgeLuckpermsSyncCron.js
+ *
+ * Periodically syncs badge assignments for badges linked to a LuckPerms group.
+ *
+ * Logic:
+ *  1. Find all badges that have a luckpermsGroup set.
+ *  2. For each such badge, look up all website users who currently have that LP group.
+ *  3. Grant the badge (non-manual) to users who have the group but don't have the badge.
+ *  4. Remove the badge (non-manual only) from users who no longer have the group.
+ *
+ * Runs every 15 minutes.
+ */
+
+import cron from "node-cron";
+import { PrismaClient } from "@prisma/client";
+import db, { luckpermsDb } from "../controllers/databaseController.js";
+import {
+  getAllBadges,
+  syncLuckpermsBadge,
+} from "../controllers/badgeController.js";
+
+const prisma = new PrismaClient();
+
+async function syncBadgesFromLuckperms() {
+  try {
+    const allBadges = await getAllBadges();
+    const lpLinkedBadges = allBadges.filter((b) => b.luckpermsGroup);
+
+    if (lpLinkedBadges.length === 0) return;
+
+    for (const badge of lpLinkedBadges) {
+      try {
+        await syncOneBadge(badge);
+      } catch (err) {
+        console.error(`[badge-sync] Error syncing badge #${badge.badgeId} (${badge.name}):`, err);
+      }
+    }
+  } catch (err) {
+    console.error("[badge-sync] Fatal error during LP badge sync:", err);
+  }
+}
+
+async function syncOneBadge(badge) {
+  const groupSlug = badge.luckpermsGroup;
+
+  // Get all user UUIDs in the LP group
+  const lpRows = await new Promise((resolve, reject) => {
+    luckpermsDb.query(
+      `SELECT uuid FROM luckperms_user_permissions
+        WHERE permission = ? AND value = 1`,
+      [`group.${groupSlug}`],
+      (err, rows) => {
+        if (err) return reject(err);
+        resolve(rows || []);
+      }
+    );
+  });
+
+  if (lpRows.length === 0) {
+    // No one has this group — remove all non-manual badge assignments
+    await syncLuckpermsBadge(badge.badgeId, []);
+    return;
+  }
+
+  const lpUuids = lpRows.map((r) => String(r.uuid).toLowerCase());
+
+  // Map LuckPerms UUIDs → website userIds
+  const placeholders = lpUuids.map(() => "?").join(", ");
+  const webUsers = await new Promise((resolve, reject) => {
+    db.query(
+      `SELECT userId, uuid FROM users WHERE LOWER(uuid) IN (${placeholders})`,
+      lpUuids,
+      (err, rows) => {
+        if (err) return reject(err);
+        resolve(rows || []);
+      }
+    );
+  });
+
+  const userIds = webUsers.map((u) => u.userId);
+  await syncLuckpermsBadge(badge.badgeId, userIds);
+}
+
+// Run every 15 minutes
+cron.schedule("*/15 * * * *", () => {
+  syncBadgesFromLuckperms();
+});
+
+// Also run once on startup (after a short delay to let the DB pool settle)
+setTimeout(() => {
+  syncBadgesFromLuckperms();
+}, 10_000);

--- a/prisma/migrations/0014_badge_system/migration.sql
+++ b/prisma/migrations/0014_badge_system/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE `badges` (
+    `badgeId` INTEGER NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(100) NOT NULL,
+    `description` TEXT NULL,
+    `itemIcon` VARCHAR(100) NOT NULL,
+    `backgroundColor` VARCHAR(7) NOT NULL DEFAULT '#1a1a2e',
+    `luckpermsGroup` VARCHAR(64) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    PRIMARY KEY (`badgeId`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `user_badges` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `userId` INTEGER NOT NULL,
+    `badgeId` INTEGER NOT NULL,
+    `earnedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `isManual` BOOLEAN NOT NULL DEFAULT false,
+
+    INDEX `user_badges_userId_idx`(`userId`),
+    UNIQUE INDEX `user_badges_userId_badgeId_key`(`userId`, `badgeId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `user_badges` ADD CONSTRAINT `user_badges_badgeId_fkey` FOREIGN KEY (`badgeId`) REFERENCES `badges`(`badgeId`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/0014_badge_system/migration.sql
+++ b/prisma/migrations/0014_badge_system/migration.sql
@@ -1,29 +1,29 @@
--- CreateTable
+-- Badge System: adds badges definition table and user badge assignment table.
+
 CREATE TABLE `badges` (
-    `badgeId` INTEGER NOT NULL AUTO_INCREMENT,
-    `name` VARCHAR(100) NOT NULL,
-    `description` TEXT NULL,
-    `itemIcon` VARCHAR(100) NOT NULL,
-    `backgroundColor` VARCHAR(7) NOT NULL DEFAULT '#1a1a2e',
-    `luckpermsGroup` VARCHAR(64) NULL,
-    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-    `updatedAt` DATETIME(3) NOT NULL,
-
-    PRIMARY KEY (`badgeId`)
+  `badgeId`         INT           NOT NULL AUTO_INCREMENT,
+  `name`            VARCHAR(100)  NOT NULL,
+  `description`     TEXT          NULL,
+  `itemIcon`        VARCHAR(100)  NOT NULL,
+  `backgroundColor` VARCHAR(7)    NOT NULL DEFAULT '#1a1a2e',
+  `luckpermsGroup`  VARCHAR(64)   NULL,
+  `createdAt`       DATETIME(3)   NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updatedAt`       DATETIME(3)   NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (`badgeId`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
--- CreateTable
 CREATE TABLE `user_badges` (
-    `id` INTEGER NOT NULL AUTO_INCREMENT,
-    `userId` INTEGER NOT NULL,
-    `badgeId` INTEGER NOT NULL,
-    `earnedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-    `isManual` BOOLEAN NOT NULL DEFAULT false,
-
-    INDEX `user_badges_userId_idx`(`userId`),
-    UNIQUE INDEX `user_badges_userId_badgeId_key`(`userId`, `badgeId`),
-    PRIMARY KEY (`id`)
+  `id`        INT         NOT NULL AUTO_INCREMENT,
+  `userId`    INT         NOT NULL,
+  `badgeId`   INT         NOT NULL,
+  `earnedAt`  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `isManual`  TINYINT(1)  NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`),
+  INDEX `user_badges_userId_idx` (`userId`),
+  UNIQUE INDEX `user_badges_userId_badgeId_key` (`userId`, `badgeId`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
--- AddForeignKey
-ALTER TABLE `user_badges` ADD CONSTRAINT `user_badges_badgeId_fkey` FOREIGN KEY (`badgeId`) REFERENCES `badges`(`badgeId`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE `user_badges`
+  ADD CONSTRAINT `user_badges_badgeId_fkey`
+  FOREIGN KEY (`badgeId`) REFERENCES `badges`(`badgeId`)
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/0015_badge_text_colour/migration.sql
+++ b/prisma/migrations/0015_badge_text_colour/migration.sql
@@ -1,0 +1,5 @@
+-- Add textColor column to badges table for per-badge text colour control.
+
+ALTER TABLE `badges`
+  ADD COLUMN `textColor` VARCHAR(7) NOT NULL DEFAULT '#ffffff'
+  AFTER `backgroundColor`;

--- a/prisma/migrations/0016_badge_remove_item_icon/migration.sql
+++ b/prisma/migrations/0016_badge_remove_item_icon/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `badges` DROP COLUMN `itemIcon`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -875,7 +875,6 @@ model badges {
   badgeId         Int           @id @default(autoincrement())
   name            String        @db.VarChar(100)
   description     String?       @db.Text
-  itemIcon        String        @db.VarChar(100)
   backgroundColor String        @default("#1a1a2e") @db.VarChar(7)
   textColor       String        @default("#ffffff") @db.VarChar(7)
   luckpermsGroup  String?       @db.VarChar(64)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -877,6 +877,7 @@ model badges {
   description     String?       @db.Text
   itemIcon        String        @db.VarChar(100)
   backgroundColor String        @default("#1a1a2e") @db.VarChar(7)
+  textColor       String        @default("#ffffff") @db.VarChar(7)
   luckpermsGroup  String?       @db.VarChar(64)
   createdAt       DateTime      @default(now())
   updatedAt       DateTime      @updatedAt

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -866,3 +866,33 @@ model event_audit_logs {
 
   event          events   @relation(fields: [eventId], references: [eventId], onDelete: Cascade)
 }
+
+// =============================================================================
+// Badge System
+// =============================================================================
+
+model badges {
+  badgeId         Int           @id @default(autoincrement())
+  name            String        @db.VarChar(100)
+  description     String?       @db.Text
+  itemIcon        String        @db.VarChar(100)
+  backgroundColor String        @default("#1a1a2e") @db.VarChar(7)
+  luckpermsGroup  String?       @db.VarChar(64)
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime      @updatedAt
+
+  userBadges      user_badges[]
+}
+
+model user_badges {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  badgeId   Int
+  earnedAt  DateTime @default(now())
+  isManual  Boolean  @default(false)
+
+  badge     badges   @relation(fields: [badgeId], references: [badgeId], onDelete: Cascade)
+
+  @@unique([userId, badgeId])
+  @@index([userId])
+}

--- a/routes/dashboard/badges.js
+++ b/routes/dashboard/badges.js
@@ -1,0 +1,227 @@
+/**
+ * routes/dashboard/badges.js
+ *
+ * Admin dashboard routes for the Badge system.
+ *
+ *   GET  /dashboard/badges                    — badge list & management
+ *   GET  /dashboard/badges/create             — create badge form
+ *   GET  /dashboard/badges/:id/edit           — edit badge form
+ *   GET  /dashboard/badges/:id/assign         — assign badge to a user form
+ *
+ * Session-authenticated proxy routes (forward to /admin/badges API):
+ *   POST   /dashboard/badges
+ *   PUT    /dashboard/badges/:id
+ *   DELETE /dashboard/badges/:id
+ *   POST   /dashboard/badges/:id/duplicate
+ *   POST   /dashboard/badges/:id/assign/:userId
+ *   DELETE /dashboard/badges/:id/assign/:userId
+ */
+
+import {
+  getGlobalImage,
+  hasPermission,
+} from "../../api/common.js";
+import { getWebAnnouncement } from "../../controllers/announcementController.js";
+import { UserGetter } from "../../controllers/userController.js";
+
+async function proxyToApi(fetch, method, path, body) {
+  const res = await fetch(`${process.env.siteAddress}${path}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      "x-access-token": process.env.apiKey,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return res.json();
+}
+
+export default function dashboardBadgesRoute(app, fetch, config, db, features, lang) {
+
+  // =========================================================================
+  // GET /dashboard/badges — badge list & management
+  // =========================================================================
+  app.get("/dashboard/badges", async function (req, res) {
+    if (!await hasPermission("zander.web.badges", req, res, features)) return;
+
+    let badgesData = { success: false, data: [] };
+    try {
+      const r = await fetch(`${process.env.siteAddress}/admin/badges`, {
+        headers: { "x-access-token": process.env.apiKey },
+      });
+      badgesData = await r.json();
+    } catch (error) {
+      console.error("[dashboard/badges] Failed to fetch badges:", error);
+    }
+
+    const [globalImage, announcementWeb] = await Promise.all([getGlobalImage(), getWebAnnouncement()]);
+    res.header("content-type", "text/html; charset=utf-8").send(
+      await app.view("dashboard/badges/index", {
+        pageTitle: "Dashboard - Badges",
+        config,
+        req,
+        features,
+        badgesData,
+        globalImage,
+        announcementWeb,
+      })
+    );
+    return;
+  });
+
+  // =========================================================================
+  // GET /dashboard/badges/create — create badge form
+  // =========================================================================
+  app.get("/dashboard/badges/create", async function (req, res) {
+    if (!await hasPermission("zander.web.badges", req, res, features)) return;
+
+    const [globalImage, announcementWeb] = await Promise.all([getGlobalImage(), getWebAnnouncement()]);
+    res.header("content-type", "text/html; charset=utf-8").send(
+      await app.view("dashboard/badges/edit", {
+        pageTitle: "Dashboard - Create Badge",
+        config,
+        req,
+        features,
+        badge: null,
+        globalImage,
+        announcementWeb,
+      })
+    );
+    return;
+  });
+
+  // =========================================================================
+  // GET /dashboard/badges/:id/edit — edit badge form
+  // =========================================================================
+  app.get("/dashboard/badges/:id/edit", async function (req, res) {
+    if (!await hasPermission("zander.web.badges", req, res, features)) return;
+
+    const id = parseInt(req.params.id, 10);
+    if (!id) return res.redirect("/dashboard/badges");
+
+    let badge = null;
+    try {
+      const r = await fetch(`${process.env.siteAddress}/admin/badges`, {
+        headers: { "x-access-token": process.env.apiKey },
+      });
+      const all = await r.json();
+      badge = (all.data || []).find((b) => b.badgeId === id) || null;
+    } catch (error) {
+      console.error("[dashboard/badges] Failed to fetch badge for edit:", error);
+    }
+
+    if (!badge) return res.redirect("/dashboard/badges");
+
+    const [globalImage, announcementWeb] = await Promise.all([getGlobalImage(), getWebAnnouncement()]);
+    res.header("content-type", "text/html; charset=utf-8").send(
+      await app.view("dashboard/badges/edit", {
+        pageTitle: "Dashboard - Edit Badge",
+        config,
+        req,
+        features,
+        badge,
+        globalImage,
+        announcementWeb,
+      })
+    );
+    return;
+  });
+
+  // =========================================================================
+  // GET /dashboard/badges/:id/assign — assign badge to user form
+  // =========================================================================
+  app.get("/dashboard/badges/:id/assign", async function (req, res) {
+    if (!await hasPermission("zander.web.badges", req, res, features)) return;
+
+    const id = parseInt(req.params.id, 10);
+    if (!id) return res.redirect("/dashboard/badges");
+
+    let badge = null;
+    try {
+      const r = await fetch(`${process.env.siteAddress}/admin/badges`, {
+        headers: { "x-access-token": process.env.apiKey },
+      });
+      const all = await r.json();
+      badge = (all.data || []).find((b) => b.badgeId === id) || null;
+    } catch (error) {
+      console.error("[dashboard/badges] Failed to fetch badge for assign:", error);
+    }
+
+    if (!badge) return res.redirect("/dashboard/badges");
+
+    const [globalImage, announcementWeb] = await Promise.all([getGlobalImage(), getWebAnnouncement()]);
+    res.header("content-type", "text/html; charset=utf-8").send(
+      await app.view("dashboard/badges/assign", {
+        pageTitle: "Dashboard - Assign Badge",
+        config,
+        req,
+        features,
+        badge,
+        globalImage,
+        announcementWeb,
+      })
+    );
+    return;
+  });
+
+  // =========================================================================
+  // Session-authenticated proxy routes
+  // =========================================================================
+
+  app.post("/dashboard/badges", async (req, res) => {
+    if (!await hasPermission("zander.web.badges", req, res, features)) return;
+    res.send(await proxyToApi(fetch, "POST", "/admin/badges", req.body));
+    return;
+  });
+
+  app.put("/dashboard/badges/:id", async (req, res) => {
+    if (!await hasPermission("zander.web.badges", req, res, features)) return;
+    res.send(await proxyToApi(fetch, "PUT", `/admin/badges/${req.params.id}`, req.body));
+    return;
+  });
+
+  app.delete("/dashboard/badges/:id", async (req, res) => {
+    if (!await hasPermission("zander.web.badges", req, res, features)) return;
+    res.send(await proxyToApi(fetch, "DELETE", `/admin/badges/${req.params.id}`));
+    return;
+  });
+
+  app.post("/dashboard/badges/:id/duplicate", async (req, res) => {
+    if (!await hasPermission("zander.web.badges", req, res, features)) return;
+    res.send(await proxyToApi(fetch, "POST", `/admin/badges/${req.params.id}/duplicate`));
+    return;
+  });
+
+  app.post("/dashboard/badges/:id/assign/:userId", async (req, res) => {
+    if (!await hasPermission("zander.web.badges", req, res, features)) return;
+    res.send(await proxyToApi(fetch, "POST", `/admin/badges/${req.params.id}/assign/${req.params.userId}`));
+    return;
+  });
+
+  app.delete("/dashboard/badges/:id/assign/:userId", async (req, res) => {
+    if (!await hasPermission("zander.web.badges", req, res, features)) return;
+    res.send(await proxyToApi(fetch, "DELETE", `/admin/badges/${req.params.id}/assign/${req.params.userId}`));
+    return;
+  });
+
+  // Search users for the assign form (session-authenticated proxy)
+  app.get("/dashboard/badges/user-search", async (req, res) => {
+    if (!await hasPermission("zander.web.badges", req, res, features)) return;
+
+    const q = (req.query.q || "").trim();
+    if (!q || q.length < 2) return res.send({ success: false, data: [] });
+
+    try {
+      const getter = new UserGetter();
+      const user = await getter.byUsername(q);
+      if (!user) return res.send({ success: true, data: [] });
+      return res.send({
+        success: true,
+        data: [{ userId: user.userId, username: user.username }],
+      });
+    } catch (error) {
+      console.error("[dashboard/badges] user-search error:", error);
+      if (!res.sent) return res.status(500).send({ success: false, data: [] });
+    }
+  });
+}

--- a/routes/dashboard/badges.js
+++ b/routes/dashboard/badges.js
@@ -24,6 +24,11 @@ import {
 import { getWebAnnouncement } from "../../controllers/announcementController.js";
 import db from "../../controllers/databaseController.js";
 import { getProfilePicture } from "../../controllers/userController.js";
+import {
+  assignBadgeToUser,
+  removeBadgeFromUser,
+  getBadgeById,
+} from "../../controllers/badgeController.js";
 
 async function proxyToApi(fetch, method, path, body) {
   const res = await fetch(`${process.env.siteAddress}${path}`, {
@@ -228,14 +233,32 @@ export default function dashboardBadgesRoute(app, fetch, config, db, features, l
 
   app.post("/dashboard/badges/:id/assign/:userId", async (req, res) => {
     if (!await hasPermission("zander.web.badges", req, res, features)) return;
-    res.send(await proxyToApi(fetch, "POST", `/admin/badges/${req.params.id}/assign/${req.params.userId}`));
-    return;
+    const badgeId = parseInt(req.params.id, 10);
+    const userId  = parseInt(req.params.userId, 10);
+    if (!badgeId || !userId) return res.send({ success: false, message: "Invalid badge or user id." });
+    try {
+      const badge = await getBadgeById(badgeId);
+      if (!badge) return res.send({ success: false, message: "Badge not found." });
+      await assignBadgeToUser(userId, badgeId);
+      return res.send({ success: true, message: "Badge assigned." });
+    } catch (err) {
+      console.error("[dashboard/badges] assign error:", err);
+      return res.send({ success: false, message: err.message || "Failed to assign badge." });
+    }
   });
 
   app.delete("/dashboard/badges/:id/assign/:userId", async (req, res) => {
     if (!await hasPermission("zander.web.badges", req, res, features)) return;
-    res.send(await proxyToApi(fetch, "DELETE", `/admin/badges/${req.params.id}/assign/${req.params.userId}`));
-    return;
+    const badgeId = parseInt(req.params.id, 10);
+    const userId  = parseInt(req.params.userId, 10);
+    if (!badgeId || !userId) return res.send({ success: false, message: "Invalid badge or user id." });
+    try {
+      await removeBadgeFromUser(userId, badgeId);
+      return res.send({ success: true, message: "Badge removed from user." });
+    } catch (err) {
+      console.error("[dashboard/badges] remove error:", err);
+      return res.send({ success: false, message: err.message || "Failed to remove badge." });
+    }
   });
 
 }

--- a/routes/dashboard/badges.js
+++ b/routes/dashboard/badges.js
@@ -22,7 +22,8 @@ import {
   hasPermission,
 } from "../../api/common.js";
 import { getWebAnnouncement } from "../../controllers/announcementController.js";
-import { UserGetter } from "../../controllers/userController.js";
+import db from "../../controllers/databaseController.js";
+import { getProfilePicture } from "../../controllers/userController.js";
 
 async function proxyToApi(fetch, method, path, body) {
   const res = await fetch(`${process.env.siteAddress}${path}`, {
@@ -204,24 +205,35 @@ export default function dashboardBadgesRoute(app, fetch, config, db, features, l
     return;
   });
 
-  // Search users for the assign form (session-authenticated proxy)
+  // User autocomplete for the assign form (session-authenticated, prefix search)
   app.get("/dashboard/badges/user-search", async (req, res) => {
     if (!await hasPermission("zander.web.badges", req, res, features)) return;
 
     const q = (req.query.q || "").trim();
-    if (!q || q.length < 2) return res.send({ success: false, data: [] });
+    if (!q || q.length < 2) return res.send({ results: [] });
 
     try {
-      const getter = new UserGetter();
-      const user = await getter.byUsername(q);
-      if (!user) return res.send({ success: true, data: [] });
-      return res.send({
-        success: true,
-        data: [{ userId: user.userId, username: user.username }],
+      const rows = await new Promise((resolve, reject) => {
+        db.query(
+          `SELECT userId, username, uuid, profilePicture_type, profilePicture_email
+             FROM users WHERE username LIKE ? ORDER BY username ASC LIMIT 8`,
+          [`${q}%`],
+          (err, results) => { if (err) return reject(err); resolve(results || []); }
+        );
       });
+
+      const results = await Promise.all(
+        rows.map(async (row) => ({
+          userId: row.userId,
+          username: row.username,
+          avatarUrl: await getProfilePicture(row.username),
+        }))
+      );
+
+      return res.send({ results });
     } catch (error) {
       console.error("[dashboard/badges] user-search error:", error);
-      if (!res.sent) return res.status(500).send({ success: false, data: [] });
+      if (!res.sent) return res.status(500).send({ results: [] });
     }
   });
 }

--- a/routes/dashboard/badges.js
+++ b/routes/dashboard/badges.js
@@ -91,6 +91,39 @@ export default function dashboardBadgesRoute(app, fetch, config, db, features, l
     return;
   });
 
+  // User autocomplete for the assign form (session-authenticated, prefix search)
+  // Registered before parameterized routes so Fastify's static-segment preference is explicit.
+  app.get("/dashboard/badges/user-search", async (req, res) => {
+    if (!await hasPermission("zander.web.badges", req, res, features)) return;
+
+    const q = (req.query.q || "").trim();
+    if (!q || q.length < 2) return res.send({ results: [] });
+
+    try {
+      const rows = await new Promise((resolve, reject) => {
+        db.query(
+          `SELECT userId, username, uuid, profilePicture_type, profilePicture_email
+             FROM users WHERE username LIKE ? ORDER BY username ASC LIMIT 8`,
+          [`${q}%`],
+          (err, results) => { if (err) return reject(err); resolve(results || []); }
+        );
+      });
+
+      const results = await Promise.all(
+        rows.map(async (row) => ({
+          userId: row.userId,
+          username: row.username,
+          avatarUrl: await getProfilePicture(row.username),
+        }))
+      );
+
+      return res.send({ results });
+    } catch (error) {
+      console.error("[dashboard/badges] user-search error:", error);
+      if (!res.sent) return res.status(500).send({ results: [] });
+    }
+  });
+
   // =========================================================================
   // GET /dashboard/badges/:id/edit — edit badge form
   // =========================================================================
@@ -205,35 +238,4 @@ export default function dashboardBadgesRoute(app, fetch, config, db, features, l
     return;
   });
 
-  // User autocomplete for the assign form (session-authenticated, prefix search)
-  app.get("/dashboard/badges/user-search", async (req, res) => {
-    if (!await hasPermission("zander.web.badges", req, res, features)) return;
-
-    const q = (req.query.q || "").trim();
-    if (!q || q.length < 2) return res.send({ results: [] });
-
-    try {
-      const rows = await new Promise((resolve, reject) => {
-        db.query(
-          `SELECT userId, username, uuid, profilePicture_type, profilePicture_email
-             FROM users WHERE username LIKE ? ORDER BY username ASC LIMIT 8`,
-          [`${q}%`],
-          (err, results) => { if (err) return reject(err); resolve(results || []); }
-        );
-      });
-
-      const results = await Promise.all(
-        rows.map(async (row) => ({
-          userId: row.userId,
-          username: row.username,
-          avatarUrl: await getProfilePicture(row.username),
-        }))
-      );
-
-      return res.send({ results });
-    } catch (error) {
-      console.error("[dashboard/badges] user-search error:", error);
-      if (!res.sent) return res.status(500).send({ results: [] });
-    }
-  });
 }

--- a/routes/dashboard/index.js
+++ b/routes/dashboard/index.js
@@ -13,6 +13,7 @@ import dashboardFormsSiteRoute from "./forms.js";
 import dashboardWebPunishmentsRoute from "./webPunishments.js";
 import dashboardVotingRoute from "./voting.js";
 import dashboardEventsRoute from "./events.js";
+import dashboardBadgesRoute from "./badges.js";
 
 export default function dashboardSiteRoutes(
   app,
@@ -52,4 +53,5 @@ export default function dashboardSiteRoutes(
   dashboardWebPunishmentsRoute(app, client, fetch, config, db, features, lang);
   dashboardVotingRoute(app, fetch, config, db, features, lang);
   dashboardEventsRoute(app, fetch, config, db, features, lang);
+  dashboardBadgesRoute(app, fetch, config, db, features, lang);
 }

--- a/routes/dashboard/ranks.js
+++ b/routes/dashboard/ranks.js
@@ -4,6 +4,7 @@ import {
 } from "../../api/common.js";
 import { getWebAnnouncement } from "../../controllers/announcementController.js";
 import { luckpermsDb } from "../../controllers/databaseController.js";
+import { getProfilePicture } from "../../controllers/userController.js";
 
 /**
  * Query LuckPerms directly for all rank groups.
@@ -101,6 +102,38 @@ export default function dashboardRanksRoute(
   features,
   lang
 ) {
+  // User prefix search for the username autocomplete on the rank tools form
+  app.get("/dashboard/ranks/user-search", async (req, res) => {
+    if (!await isFeatureWebRouteEnabled(app, features.ranks, req, res, features)) return;
+    if (!await hasPermission("zander.web.rank", req, res, features)) return;
+
+    const q = (req.query.q || "").trim();
+    if (!q || q.length < 2) return res.send({ results: [] });
+
+    try {
+      const rows = await new Promise((resolve, reject) => {
+        db.query(
+          `SELECT userId, username FROM users WHERE username LIKE ? ORDER BY username ASC LIMIT 8`,
+          [`${q}%`],
+          (err, results) => { if (err) return reject(err); resolve(results || []); }
+        );
+      });
+
+      const results = await Promise.all(
+        rows.map(async (row) => ({
+          userId: row.userId,
+          username: row.username,
+          avatarUrl: await getProfilePicture(row.username),
+        }))
+      );
+
+      return res.send({ results });
+    } catch (error) {
+      console.error("[dashboard/ranks] user-search error:", error);
+      if (!res.sent) return res.status(500).send({ results: [] });
+    }
+  });
+
   app.get("/dashboard/ranks", async function (req, res) {
     if (!await isFeatureWebRouteEnabled(app, features.ranks, req, res, features)) return;
 

--- a/routes/profileRoutes.js
+++ b/routes/profileRoutes.js
@@ -19,6 +19,7 @@ import {
   getReportsByReporterId,
   getUserPunishments,
 } from "../services/profileService.js";
+import { getBadgesForUser } from "../controllers/badgeController.js";
 import {
   getDiscordPunishmentsForProfile,
   hasActiveWebBan,
@@ -225,6 +226,16 @@ export default function profileSiteRoutes(
         }
 
         //
+        // Load badges for profile
+        //
+        let profileBadges = [];
+        try {
+          profileBadges = await getBadgesForUser(profileData.userId);
+        } catch (err) {
+          console.error("[PROFILE] Failed to load badges for profile", err);
+        }
+
+        //
         // Render the profile page
         //
         res.header("content-type", "text/html; charset=utf-8").send(
@@ -248,6 +259,7 @@ export default function profileSiteRoutes(
           moment: moment,
           contextPermissions: contextPermissions,
           platformConnections: profilePlatformConnections,
+          profileBadges: profileBadges,
         }));
         return;
       }

--- a/routes/support.js
+++ b/routes/support.js
@@ -822,9 +822,12 @@ export default function supportRoutes(
         participants.groups.some((group) => group.rankSlug === slug)
       );
       const isAppealAddUser = /Appeal #/i.test(ticket.title || "");
-      const canManageParticipantsAddUser = userHasPermissionNode(req.session.user.permissions || [], "zander.web.tickets.manageparticipants") || !isAppealAddUser;
+      const hasMgParticipantsPermAddUser = userHasPermissionNode(req.session.user.permissions || [], "zander.web.tickets.manageparticipants");
 
-      if (!canManageParticipantsAddUser || (!isOwner && !isStaff && !isParticipantUser && !isParticipantRank)) {
+      if (isAppealAddUser && !hasMgParticipantsPermAddUser) {
+        return res.redirect("/support");
+      }
+      if (!hasMgParticipantsPermAddUser && !isOwner && !isStaff && !isParticipantUser && !isParticipantRank) {
         return res.redirect("/support");
       }
 
@@ -894,9 +897,12 @@ export default function supportRoutes(
         participants.groups.some((group) => group.rankSlug === slug)
       );
       const isAppealAddGroup = /Appeal #/i.test(ticket.title || "");
-      const canManageParticipantsAddGroup = userHasPermissionNode(req.session.user.permissions || [], "zander.web.tickets.manageparticipants") || !isAppealAddGroup;
+      const hasMgParticipantsPermAddGroup = userHasPermissionNode(req.session.user.permissions || [], "zander.web.tickets.manageparticipants");
 
-      if (!canManageParticipantsAddGroup || (!isOwner && !isStaff && !isParticipantUser && !isParticipantRank)) {
+      if (isAppealAddGroup && !hasMgParticipantsPermAddGroup) {
+        return res.redirect("/support");
+      }
+      if (!hasMgParticipantsPermAddGroup && !isOwner && !isStaff && !isParticipantUser && !isParticipantRank) {
         return res.redirect("/support");
       }
 
@@ -961,9 +967,12 @@ export default function supportRoutes(
         participants.groups.some((group) => group.rankSlug === slug)
       );
       const isAppealRemoveUser = /Appeal #/i.test(ticket.title || "");
-      const canManageParticipantsRemoveUser = userHasPermissionNode(req.session.user.permissions || [], "zander.web.tickets.manageparticipants") || !isAppealRemoveUser;
+      const hasMgParticipantsPermRemoveUser = userHasPermissionNode(req.session.user.permissions || [], "zander.web.tickets.manageparticipants");
 
-      if (!canManageParticipantsRemoveUser || (!isOwner && !isStaff && !isParticipantUser && !isParticipantRank)) {
+      if (isAppealRemoveUser && !hasMgParticipantsPermRemoveUser) {
+        return res.redirect("/support");
+      }
+      if (!hasMgParticipantsPermRemoveUser && !isOwner && !isStaff && !isParticipantUser && !isParticipantRank) {
         return res.redirect("/support");
       }
 
@@ -1041,9 +1050,12 @@ export default function supportRoutes(
         participants.groups.some((group) => group.rankSlug === slug)
       );
       const isAppealRemoveGroup = /Appeal #/i.test(ticket.title || "");
-      const canManageParticipantsRemoveGroup = userHasPermissionNode(req.session.user.permissions || [], "zander.web.tickets.manageparticipants") || !isAppealRemoveGroup;
+      const hasMgParticipantsPermRemoveGroup = userHasPermissionNode(req.session.user.permissions || [], "zander.web.tickets.manageparticipants");
 
-      if (!canManageParticipantsRemoveGroup || (!isOwner && !isStaff && !isParticipantUser && !isParticipantRank)) {
+      if (isAppealRemoveGroup && !hasMgParticipantsPermRemoveGroup) {
+        return res.redirect("/support");
+      }
+      if (!hasMgParticipantsPermRemoveGroup && !isOwner && !isStaff && !isParticipantUser && !isParticipantRank) {
         return res.redirect("/support");
       }
 

--- a/views/dashboard/badges/assign.ejs
+++ b/views/dashboard/badges/assign.ejs
@@ -1,0 +1,256 @@
+<%- include("../../admin/_head.ejs", { pageTitle }) %>
+<%- include("../../admin/_topbar.ejs") %>
+<%- include("../../admin/_sidebar.ejs") %>
+
+<div id="wpcontent">
+  <div id="wpbody-content">
+    <div class="wrap">
+
+      <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2">
+          <i class="fa-solid fa-user-plus me-2"></i>Assign Badge
+        </h1>
+        <div class="btn-toolbar mb-2 mb-md-0">
+          <a href="/dashboard/badges" class="btn btn-sm btn-outline-secondary">
+            <i class="fa-solid fa-arrow-left me-1"></i>Back to Badges
+          </a>
+        </div>
+      </div>
+
+      <%- include("../../admin/_notices.ejs") %>
+
+      <div class="row g-4">
+        <div class="col-lg-5">
+          <!-- Badge preview -->
+          <div class="card shadow-sm mb-4">
+            <div class="card-body p-4">
+              <h6 class="text-muted text-uppercase mb-3">Badge</h6>
+              <div class="mc-badge-toast" style="background-color: <%= badge.backgroundColor %>;">
+                <img
+                  src="https://mc.nerobot.ru/img/items/<%= badge.itemIcon %>.png"
+                  alt="<%= badge.itemIcon %>"
+                  class="mc-badge-icon"
+                  onerror="this.src='/images/siteLogo.png'"
+                >
+                <div class="mc-badge-text">
+                  <span class="mc-badge-achievement">Achievement Unlocked</span>
+                  <span class="mc-badge-name"><%= badge.name %></span>
+                </div>
+              </div>
+              <% if (badge.description) { %>
+                <p class="text-muted small mt-2 mb-0"><%= badge.description %></p>
+              <% } %>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-7">
+          <!-- Assign to user -->
+          <div class="card shadow-sm mb-4">
+            <div class="card-body p-4">
+              <h6 class="text-muted text-uppercase mb-3">Assign to User</h6>
+              <div id="assignError" class="alert alert-danger d-none mb-3"></div>
+              <div id="assignSuccess" class="alert alert-success d-none mb-3"></div>
+
+              <div class="mb-3">
+                <label class="form-label fw-semibold">Minecraft Username</label>
+                <div class="input-group">
+                  <input type="text" class="form-control" id="assignUsername" placeholder="Steve">
+                  <button class="btn btn-outline-secondary" type="button" id="btnLookup">
+                    <i class="fa-solid fa-magnifying-glass"></i> Lookup
+                  </button>
+                </div>
+              </div>
+
+              <div id="userResult" class="d-none mb-3">
+                <div class="d-flex align-items-center gap-3 p-3 border rounded">
+                  <img id="userAvatar" src="" alt="Avatar" style="width:40px;height:40px;border-radius:4px;">
+                  <div>
+                    <strong id="userDisplayName"></strong>
+                    <div class="text-muted small">User ID: <span id="userIdDisplay"></span></div>
+                  </div>
+                </div>
+              </div>
+
+              <input type="hidden" id="foundUserId">
+
+              <button type="button" class="btn btn-success" id="btnAssign" disabled>
+                <i class="fa-solid fa-user-plus me-1"></i>Assign Badge
+              </button>
+            </div>
+          </div>
+
+          <!-- Remove from user -->
+          <div class="card shadow-sm">
+            <div class="card-body p-4">
+              <h6 class="text-muted text-uppercase mb-3">Remove from User</h6>
+              <div id="removeError" class="alert alert-danger d-none mb-3"></div>
+              <div id="removeSuccess" class="alert alert-success d-none mb-3"></div>
+
+              <div class="mb-3">
+                <label class="form-label fw-semibold">Minecraft Username</label>
+                <div class="input-group">
+                  <input type="text" class="form-control" id="removeUsername" placeholder="Steve">
+                  <button class="btn btn-outline-secondary" type="button" id="btnRemoveLookup">
+                    <i class="fa-solid fa-magnifying-glass"></i> Lookup
+                  </button>
+                </div>
+              </div>
+
+              <div id="removeUserResult" class="d-none mb-3">
+                <div class="d-flex align-items-center gap-3 p-3 border rounded">
+                  <img id="removeUserAvatar" src="" alt="Avatar" style="width:40px;height:40px;border-radius:4px;">
+                  <div>
+                    <strong id="removeUserDisplayName"></strong>
+                    <div class="text-muted small">User ID: <span id="removeUserIdDisplay"></span></div>
+                  </div>
+                </div>
+              </div>
+
+              <input type="hidden" id="removeFoundUserId">
+
+              <button type="button" class="btn btn-danger" id="btnRemove" disabled>
+                <i class="fa-solid fa-user-minus me-1"></i>Remove Badge
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div><!-- /.wrap -->
+  </div><!-- /#wpbody-content -->
+  <%- include("../../admin/_footer.ejs") %>
+</div><!-- /#wpcontent -->
+
+<style>
+.mc-badge-toast {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 4px;
+  border: 2px solid rgba(255,255,255,0.15);
+  min-height: 60px;
+}
+.mc-badge-icon {
+  width: 44px;
+  height: 44px;
+  image-rendering: pixelated;
+  flex-shrink: 0;
+}
+.mc-badge-text { display: flex; flex-direction: column; }
+.mc-badge-achievement {
+  font-size: 10px;
+  color: rgba(255,255,255,0.65);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.mc-badge-name {
+  font-size: 15px;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 1px 1px 2px rgba(0,0,0,0.8);
+}
+</style>
+
+<script>
+const badgeId = <%= badge.badgeId %>;
+
+async function lookupUser(username) {
+  const r = await fetch(`/dashboard/badges/user-search?q=${encodeURIComponent(username)}`);
+  const data = await r.json();
+  return (data.success && data.data && data.data[0]) ? data.data[0] : null;
+}
+
+// Assign — lookup
+document.getElementById('btnLookup').addEventListener('click', async () => {
+  const username = document.getElementById('assignUsername').value.trim();
+  if (!username) return;
+
+  const user = await lookupUser(username);
+  const resultEl = document.getElementById('userResult');
+  const btnAssign = document.getElementById('btnAssign');
+
+  if (!user) {
+    resultEl.classList.add('d-none');
+    btnAssign.disabled = true;
+    document.getElementById('assignError').textContent = 'User not found.';
+    document.getElementById('assignError').classList.remove('d-none');
+    return;
+  }
+
+  document.getElementById('assignError').classList.add('d-none');
+  document.getElementById('userAvatar').src = `https://craftatar.com/avatars/${user.username}?size=40&overlay`;
+  document.getElementById('userDisplayName').textContent = user.username;
+  document.getElementById('userIdDisplay').textContent = user.userId;
+  document.getElementById('foundUserId').value = user.userId;
+  resultEl.classList.remove('d-none');
+  btnAssign.disabled = false;
+});
+
+// Assign — submit
+document.getElementById('btnAssign').addEventListener('click', async () => {
+  const userId = document.getElementById('foundUserId').value;
+  const errEl = document.getElementById('assignError');
+  const okEl = document.getElementById('assignSuccess');
+  errEl.classList.add('d-none');
+  okEl.classList.add('d-none');
+
+  const r = await fetch(`/dashboard/badges/${badgeId}/assign/${userId}`, { method: 'POST' });
+  const data = await r.json();
+
+  if (data.success) {
+    okEl.textContent = `Badge assigned to ${document.getElementById('userDisplayName').textContent}.`;
+    okEl.classList.remove('d-none');
+  } else {
+    errEl.textContent = data.message || 'Failed to assign badge.';
+    errEl.classList.remove('d-none');
+  }
+});
+
+// Remove — lookup
+document.getElementById('btnRemoveLookup').addEventListener('click', async () => {
+  const username = document.getElementById('removeUsername').value.trim();
+  if (!username) return;
+
+  const user = await lookupUser(username);
+  const resultEl = document.getElementById('removeUserResult');
+  const btnRemove = document.getElementById('btnRemove');
+
+  if (!user) {
+    resultEl.classList.add('d-none');
+    btnRemove.disabled = true;
+    document.getElementById('removeError').textContent = 'User not found.';
+    document.getElementById('removeError').classList.remove('d-none');
+    return;
+  }
+
+  document.getElementById('removeError').classList.add('d-none');
+  document.getElementById('removeUserAvatar').src = `https://craftatar.com/avatars/${user.username}?size=40&overlay`;
+  document.getElementById('removeUserDisplayName').textContent = user.username;
+  document.getElementById('removeUserIdDisplay').textContent = user.userId;
+  document.getElementById('removeFoundUserId').value = user.userId;
+  resultEl.classList.remove('d-none');
+  btnRemove.disabled = false;
+});
+
+// Remove — submit
+document.getElementById('btnRemove').addEventListener('click', async () => {
+  const userId = document.getElementById('removeFoundUserId').value;
+  const errEl = document.getElementById('removeError');
+  const okEl = document.getElementById('removeSuccess');
+  errEl.classList.add('d-none');
+  okEl.classList.add('d-none');
+
+  const r = await fetch(`/dashboard/badges/${badgeId}/assign/${userId}`, { method: 'DELETE' });
+  const data = await r.json();
+
+  if (data.success) {
+    okEl.textContent = `Badge removed from ${document.getElementById('removeUserDisplayName').textContent}.`;
+    okEl.classList.remove('d-none');
+  } else {
+    errEl.textContent = data.message || 'Failed to remove badge.';
+    errEl.classList.remove('d-none');
+  }
+});
+</script>

--- a/views/dashboard/badges/assign.ejs
+++ b/views/dashboard/badges/assign.ejs
@@ -20,9 +20,9 @@
       <%- include("../../admin/_notices.ejs") %>
 
       <div class="row g-4">
-        <div class="col-lg-5">
-          <!-- Badge preview -->
-          <div class="card shadow-sm mb-4">
+        <!-- Badge preview -->
+        <div class="col-lg-4">
+          <div class="card shadow-sm">
             <div class="card-body p-4">
               <h6 class="text-muted text-uppercase mb-3">Badge</h6>
               <div class="mc-badge-toast" style="background-color: <%= badge.backgroundColor %>;">
@@ -33,18 +33,18 @@
                   onerror="this.src='/images/siteLogo.png'"
                 >
                 <div class="mc-badge-text">
-                  <span class="mc-badge-achievement">Achievement Unlocked</span>
-                  <span class="mc-badge-name"><%= badge.name %></span>
+                  <span class="mc-badge-achievement" style="color: <%= badge.textColor %>88;">Achievement Unlocked</span>
+                  <span class="mc-badge-name" style="color: <%= badge.textColor %>;"><%= badge.name %></span>
+                  <% if (badge.description) { %>
+                    <span class="mc-badge-desc" style="color: <%= badge.textColor %>cc;"><%= badge.description %></span>
+                  <% } %>
                 </div>
               </div>
-              <% if (badge.description) { %>
-                <p class="text-muted small mt-2 mb-0"><%= badge.description %></p>
-              <% } %>
             </div>
           </div>
         </div>
 
-        <div class="col-lg-7">
+        <div class="col-lg-8">
           <!-- Assign to user -->
           <div class="card shadow-sm mb-4">
             <div class="card-body p-4">
@@ -54,25 +54,25 @@
 
               <div class="mb-3">
                 <label class="form-label fw-semibold">Minecraft Username</label>
-                <div class="input-group">
-                  <input type="text" class="form-control" id="assignUsername" placeholder="Steve">
-                  <button class="btn btn-outline-secondary" type="button" id="btnLookup">
-                    <i class="fa-solid fa-magnifying-glass"></i> Lookup
-                  </button>
+                <div class="position-relative">
+                  <input type="text" class="form-control" id="assignSearch"
+                    placeholder="Start typing a username…" autocomplete="off">
+                  <div id="assignSuggestions"
+                    class="list-group position-absolute w-100 shadow-sm"
+                    style="z-index:1000;display:none;max-height:220px;overflow-y:auto;top:100%;"></div>
                 </div>
+                <input type="hidden" id="assignUserId">
               </div>
 
-              <div id="userResult" class="d-none mb-3">
+              <div id="assignUserCard" class="d-none mb-3">
                 <div class="d-flex align-items-center gap-3 p-3 border rounded">
-                  <img id="userAvatar" src="" alt="Avatar" style="width:40px;height:40px;border-radius:4px;">
+                  <img id="assignUserAvatar" src="" alt="Avatar" style="width:40px;height:40px;border-radius:4px;">
                   <div>
-                    <strong id="userDisplayName"></strong>
-                    <div class="text-muted small">User ID: <span id="userIdDisplay"></span></div>
+                    <strong id="assignUserName"></strong>
+                    <div class="text-muted small">User ID: <span id="assignUserIdDisplay"></span></div>
                   </div>
                 </div>
               </div>
-
-              <input type="hidden" id="foundUserId">
 
               <button type="button" class="btn btn-success" id="btnAssign" disabled>
                 <i class="fa-solid fa-user-plus me-1"></i>Assign Badge
@@ -89,25 +89,25 @@
 
               <div class="mb-3">
                 <label class="form-label fw-semibold">Minecraft Username</label>
-                <div class="input-group">
-                  <input type="text" class="form-control" id="removeUsername" placeholder="Steve">
-                  <button class="btn btn-outline-secondary" type="button" id="btnRemoveLookup">
-                    <i class="fa-solid fa-magnifying-glass"></i> Lookup
-                  </button>
+                <div class="position-relative">
+                  <input type="text" class="form-control" id="removeSearch"
+                    placeholder="Start typing a username…" autocomplete="off">
+                  <div id="removeSuggestions"
+                    class="list-group position-absolute w-100 shadow-sm"
+                    style="z-index:1000;display:none;max-height:220px;overflow-y:auto;top:100%;"></div>
                 </div>
+                <input type="hidden" id="removeUserId">
               </div>
 
-              <div id="removeUserResult" class="d-none mb-3">
+              <div id="removeUserCard" class="d-none mb-3">
                 <div class="d-flex align-items-center gap-3 p-3 border rounded">
                   <img id="removeUserAvatar" src="" alt="Avatar" style="width:40px;height:40px;border-radius:4px;">
                   <div>
-                    <strong id="removeUserDisplayName"></strong>
+                    <strong id="removeUserName"></strong>
                     <div class="text-muted small">User ID: <span id="removeUserIdDisplay"></span></div>
                   </div>
                 </div>
               </div>
-
-              <input type="hidden" id="removeFoundUserId">
 
               <button type="button" class="btn btn-danger" id="btnRemove" disabled>
                 <i class="fa-solid fa-user-minus me-1"></i>Remove Badge
@@ -141,66 +141,122 @@
 .mc-badge-text { display: flex; flex-direction: column; }
 .mc-badge-achievement {
   font-size: 10px;
-  color: rgba(255,255,255,0.65);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 .mc-badge-name {
   font-size: 15px;
   font-weight: 700;
-  color: #fff;
-  text-shadow: 1px 1px 2px rgba(0,0,0,0.8);
+  text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
+}
+.mc-badge-desc {
+  font-size: 11px;
+  opacity: 0.85;
+  margin-top: 2px;
 }
 </style>
 
 <script>
 const badgeId = <%= badge.badgeId %>;
 
-async function lookupUser(username) {
-  const r = await fetch(`/dashboard/badges/user-search?q=${encodeURIComponent(username)}`);
-  const data = await r.json();
-  return (data.success && data.data && data.data[0]) ? data.data[0] : null;
-}
+// ---------------------------------------------------------------------------
+// Generic autocomplete initialiser — reused for both assign and remove panels
+// ---------------------------------------------------------------------------
+function initUserAutocomplete({ searchInputId, suggestionsId, userIdHiddenId, userCardId, avatarId, nameId, idDisplayId, buttonId, onSelect }) {
+  const searchEl   = document.getElementById(searchInputId);
+  const suggestEl  = document.getElementById(suggestionsId);
+  let searchTimer  = null;
 
-// Assign — lookup
-document.getElementById('btnLookup').addEventListener('click', async () => {
-  const username = document.getElementById('assignUsername').value.trim();
-  if (!username) return;
-
-  const user = await lookupUser(username);
-  const resultEl = document.getElementById('userResult');
-  const btnAssign = document.getElementById('btnAssign');
-
-  if (!user) {
-    resultEl.classList.add('d-none');
-    btnAssign.disabled = true;
-    document.getElementById('assignError').textContent = 'User not found.';
-    document.getElementById('assignError').classList.remove('d-none');
-    return;
+  function clearSuggestions() {
+    suggestEl.innerHTML = '';
+    suggestEl.style.display = 'none';
   }
 
-  document.getElementById('assignError').classList.add('d-none');
-  document.getElementById('userAvatar').src = `https://craftatar.com/avatars/${user.username}?size=40&overlay`;
-  document.getElementById('userDisplayName').textContent = user.username;
-  document.getElementById('userIdDisplay').textContent = user.userId;
-  document.getElementById('foundUserId').value = user.userId;
-  resultEl.classList.remove('d-none');
-  btnAssign.disabled = false;
+  function renderSuggestions(results) {
+    clearSuggestions();
+    if (!results.length) return;
+    results.forEach(user => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'list-group-item list-group-item-action d-flex align-items-center gap-2 py-1 px-2';
+      if (user.avatarUrl) {
+        const img = document.createElement('img');
+        img.src = user.avatarUrl;
+        img.alt = '';
+        img.width = 28; img.height = 28;
+        img.className = 'rounded';
+        btn.appendChild(img);
+      }
+      const span = document.createElement('span');
+      span.textContent = user.username;
+      span.className = 'flex-fill text-start small';
+      btn.appendChild(span);
+      btn.addEventListener('click', () => {
+        searchEl.value = user.username;
+        clearSuggestions();
+        onSelect(user);
+      });
+      suggestEl.appendChild(btn);
+    });
+    suggestEl.style.display = 'block';
+  }
+
+  async function doSearch(term) {
+    if (!term || term.length < 2) { clearSuggestions(); return; }
+    try {
+      const r    = await fetch(`/dashboard/badges/user-search?q=${encodeURIComponent(term)}`, { credentials: 'include' });
+      const data = await r.json();
+      renderSuggestions(data.results || []);
+    } catch { clearSuggestions(); }
+  }
+
+  searchEl.addEventListener('input', e => {
+    document.getElementById(userIdHiddenId).value = '';
+    document.getElementById(buttonId).disabled = true;
+    document.getElementById(userCardId).classList.add('d-none');
+    clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => doSearch(e.target.value.trim()), 200);
+  });
+
+  document.addEventListener('click', e => {
+    if (!searchEl.contains(e.target) && !suggestEl.contains(e.target)) clearSuggestions();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Assign panel
+// ---------------------------------------------------------------------------
+initUserAutocomplete({
+  searchInputId: 'assignSearch',
+  suggestionsId: 'assignSuggestions',
+  userIdHiddenId: 'assignUserId',
+  userCardId: 'assignUserCard',
+  avatarId: 'assignUserAvatar',
+  nameId: 'assignUserName',
+  idDisplayId: 'assignUserIdDisplay',
+  buttonId: 'btnAssign',
+  onSelect(user) {
+    document.getElementById('assignUserId').value = user.userId;
+    document.getElementById('assignUserAvatar').src = user.avatarUrl || '';
+    document.getElementById('assignUserName').textContent = user.username;
+    document.getElementById('assignUserIdDisplay').textContent = user.userId;
+    document.getElementById('assignUserCard').classList.remove('d-none');
+    document.getElementById('btnAssign').disabled = false;
+    document.getElementById('assignError').classList.add('d-none');
+  },
 });
 
-// Assign — submit
 document.getElementById('btnAssign').addEventListener('click', async () => {
-  const userId = document.getElementById('foundUserId').value;
-  const errEl = document.getElementById('assignError');
-  const okEl = document.getElementById('assignSuccess');
+  const userId = document.getElementById('assignUserId').value;
+  const errEl  = document.getElementById('assignError');
+  const okEl   = document.getElementById('assignSuccess');
   errEl.classList.add('d-none');
   okEl.classList.add('d-none');
 
-  const r = await fetch(`/dashboard/badges/${badgeId}/assign/${userId}`, { method: 'POST' });
+  const r    = await fetch(`/dashboard/badges/${badgeId}/assign/${userId}`, { method: 'POST' });
   const data = await r.json();
-
   if (data.success) {
-    okEl.textContent = `Badge assigned to ${document.getElementById('userDisplayName').textContent}.`;
+    okEl.textContent = `Badge assigned to ${document.getElementById('assignUserName').textContent}.`;
     okEl.classList.remove('d-none');
   } else {
     errEl.textContent = data.message || 'Failed to assign badge.';
@@ -208,45 +264,40 @@ document.getElementById('btnAssign').addEventListener('click', async () => {
   }
 });
 
-// Remove — lookup
-document.getElementById('btnRemoveLookup').addEventListener('click', async () => {
-  const username = document.getElementById('removeUsername').value.trim();
-  if (!username) return;
-
-  const user = await lookupUser(username);
-  const resultEl = document.getElementById('removeUserResult');
-  const btnRemove = document.getElementById('btnRemove');
-
-  if (!user) {
-    resultEl.classList.add('d-none');
-    btnRemove.disabled = true;
-    document.getElementById('removeError').textContent = 'User not found.';
-    document.getElementById('removeError').classList.remove('d-none');
-    return;
-  }
-
-  document.getElementById('removeError').classList.add('d-none');
-  document.getElementById('removeUserAvatar').src = `https://craftatar.com/avatars/${user.username}?size=40&overlay`;
-  document.getElementById('removeUserDisplayName').textContent = user.username;
-  document.getElementById('removeUserIdDisplay').textContent = user.userId;
-  document.getElementById('removeFoundUserId').value = user.userId;
-  resultEl.classList.remove('d-none');
-  btnRemove.disabled = false;
+// ---------------------------------------------------------------------------
+// Remove panel
+// ---------------------------------------------------------------------------
+initUserAutocomplete({
+  searchInputId: 'removeSearch',
+  suggestionsId: 'removeSuggestions',
+  userIdHiddenId: 'removeUserId',
+  userCardId: 'removeUserCard',
+  avatarId: 'removeUserAvatar',
+  nameId: 'removeUserName',
+  idDisplayId: 'removeUserIdDisplay',
+  buttonId: 'btnRemove',
+  onSelect(user) {
+    document.getElementById('removeUserId').value = user.userId;
+    document.getElementById('removeUserAvatar').src = user.avatarUrl || '';
+    document.getElementById('removeUserName').textContent = user.username;
+    document.getElementById('removeUserIdDisplay').textContent = user.userId;
+    document.getElementById('removeUserCard').classList.remove('d-none');
+    document.getElementById('btnRemove').disabled = false;
+    document.getElementById('removeError').classList.add('d-none');
+  },
 });
 
-// Remove — submit
 document.getElementById('btnRemove').addEventListener('click', async () => {
-  const userId = document.getElementById('removeFoundUserId').value;
-  const errEl = document.getElementById('removeError');
-  const okEl = document.getElementById('removeSuccess');
+  const userId = document.getElementById('removeUserId').value;
+  const errEl  = document.getElementById('removeError');
+  const okEl   = document.getElementById('removeSuccess');
   errEl.classList.add('d-none');
   okEl.classList.add('d-none');
 
-  const r = await fetch(`/dashboard/badges/${badgeId}/assign/${userId}`, { method: 'DELETE' });
+  const r    = await fetch(`/dashboard/badges/${badgeId}/assign/${userId}`, { method: 'DELETE' });
   const data = await r.json();
-
   if (data.success) {
-    okEl.textContent = `Badge removed from ${document.getElementById('removeUserDisplayName').textContent}.`;
+    okEl.textContent = `Badge removed from ${document.getElementById('removeUserName').textContent}.`;
     okEl.classList.remove('d-none');
   } else {
     errEl.textContent = data.message || 'Failed to remove badge.';

--- a/views/dashboard/badges/assign.ejs
+++ b/views/dashboard/badges/assign.ejs
@@ -26,12 +26,6 @@
             <div class="card-body p-4">
               <h6 class="text-muted text-uppercase mb-3">Badge</h6>
               <div class="mc-badge-toast" style="background-color: <%= badge.backgroundColor %>;">
-                <img
-                  src="https://mc.nerobot.ru/img/items/<%= badge.itemIcon %>.png"
-                  alt="<%= badge.itemIcon %>"
-                  class="mc-badge-icon"
-                  onerror="this.src='/images/siteLogo.png'"
-                >
                 <div class="mc-badge-text">
                   <span class="mc-badge-achievement" style="color: <%= badge.textColor %>88;">Achievement Unlocked</span>
                   <span class="mc-badge-name" style="color: <%= badge.textColor %>;"><%= badge.name %></span>
@@ -131,12 +125,6 @@
   border-radius: 4px;
   border: 2px solid rgba(255,255,255,0.15);
   min-height: 60px;
-}
-.mc-badge-icon {
-  width: 44px;
-  height: 44px;
-  image-rendering: pixelated;
-  flex-shrink: 0;
 }
 .mc-badge-text { display: flex; flex-direction: column; }
 .mc-badge-achievement {
@@ -253,7 +241,7 @@ document.getElementById('btnAssign').addEventListener('click', async () => {
   errEl.classList.add('d-none');
   okEl.classList.add('d-none');
 
-  const r    = await fetch(`/dashboard/badges/${badgeId}/assign/${userId}`, { method: 'POST' });
+  const r    = await fetch(`/dashboard/badges/${badgeId}/assign/${userId}`, { method: 'POST', credentials: 'include' });
   const data = await r.json();
   if (data.success) {
     okEl.textContent = `Badge assigned to ${document.getElementById('assignUserName').textContent}.`;
@@ -294,7 +282,7 @@ document.getElementById('btnRemove').addEventListener('click', async () => {
   errEl.classList.add('d-none');
   okEl.classList.add('d-none');
 
-  const r    = await fetch(`/dashboard/badges/${badgeId}/assign/${userId}`, { method: 'DELETE' });
+  const r    = await fetch(`/dashboard/badges/${badgeId}/assign/${userId}`, { method: 'DELETE', credentials: 'include' });
   const data = await r.json();
   if (data.success) {
     okEl.textContent = `Badge removed from ${document.getElementById('removeUserName').textContent}.`;

--- a/views/dashboard/badges/assign.ejs
+++ b/views/dashboard/badges/assign.ejs
@@ -241,13 +241,23 @@ document.getElementById('btnAssign').addEventListener('click', async () => {
   errEl.classList.add('d-none');
   okEl.classList.add('d-none');
 
-  const r    = await fetch(`/dashboard/badges/${badgeId}/assign/${userId}`, { method: 'POST', credentials: 'include' });
-  const data = await r.json();
-  if (data.success) {
-    okEl.textContent = `Badge assigned to ${document.getElementById('assignUserName').textContent}.`;
-    okEl.classList.remove('d-none');
-  } else {
-    errEl.textContent = data.message || 'Failed to assign badge.';
+  try {
+    const r = await fetch(`/dashboard/badges/${badgeId}/assign/${userId}`, { method: 'POST', credentials: 'include' });
+    if (r.headers.get('content-type')?.includes('text/html')) {
+      errEl.textContent = `Server error (${r.status}). You may not have permission or your session has expired.`;
+      errEl.classList.remove('d-none');
+      return;
+    }
+    const data = await r.json();
+    if (data.success) {
+      okEl.textContent = `Badge assigned to ${document.getElementById('assignUserName').textContent}.`;
+      okEl.classList.remove('d-none');
+    } else {
+      errEl.textContent = data.message || 'Failed to assign badge.';
+      errEl.classList.remove('d-none');
+    }
+  } catch (e) {
+    errEl.textContent = `Unexpected error: ${e.message}`;
     errEl.classList.remove('d-none');
   }
 });
@@ -282,13 +292,23 @@ document.getElementById('btnRemove').addEventListener('click', async () => {
   errEl.classList.add('d-none');
   okEl.classList.add('d-none');
 
-  const r    = await fetch(`/dashboard/badges/${badgeId}/assign/${userId}`, { method: 'DELETE', credentials: 'include' });
-  const data = await r.json();
-  if (data.success) {
-    okEl.textContent = `Badge removed from ${document.getElementById('removeUserName').textContent}.`;
-    okEl.classList.remove('d-none');
-  } else {
-    errEl.textContent = data.message || 'Failed to remove badge.';
+  try {
+    const r = await fetch(`/dashboard/badges/${badgeId}/assign/${userId}`, { method: 'DELETE', credentials: 'include' });
+    if (r.headers.get('content-type')?.includes('text/html')) {
+      errEl.textContent = `Server error (${r.status}). You may not have permission or your session has expired.`;
+      errEl.classList.remove('d-none');
+      return;
+    }
+    const data = await r.json();
+    if (data.success) {
+      okEl.textContent = `Badge removed from ${document.getElementById('removeUserName').textContent}.`;
+      okEl.classList.remove('d-none');
+    } else {
+      errEl.textContent = data.message || 'Failed to remove badge.';
+      errEl.classList.remove('d-none');
+    }
+  } catch (e) {
+    errEl.textContent = `Unexpected error: ${e.message}`;
     errEl.classList.remove('d-none');
   }
 });

--- a/views/dashboard/badges/edit.ejs
+++ b/views/dashboard/badges/edit.ejs
@@ -1,0 +1,221 @@
+<%- include("../../admin/_head.ejs", { pageTitle }) %>
+<%- include("../../admin/_topbar.ejs") %>
+<%- include("../../admin/_sidebar.ejs") %>
+
+<div id="wpcontent">
+  <div id="wpbody-content">
+    <div class="wrap">
+
+      <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2">
+          <i class="fa-solid fa-award me-2"></i><%= badge ? 'Edit Badge' : 'Create Badge' %>
+        </h1>
+        <div class="btn-toolbar mb-2 mb-md-0">
+          <a href="/dashboard/badges" class="btn btn-sm btn-outline-secondary">
+            <i class="fa-solid fa-arrow-left me-1"></i>Back to Badges
+          </a>
+        </div>
+      </div>
+
+      <%- include("../../admin/_notices.ejs") %>
+
+      <div class="row g-4">
+        <div class="col-lg-7">
+          <div class="card shadow-sm">
+            <div class="card-body p-4">
+              <div id="formError" class="alert alert-danger d-none mb-3"></div>
+              <div id="formSuccess" class="alert alert-success d-none mb-3"></div>
+
+              <div class="mb-3">
+                <label class="form-label fw-semibold">Badge Name <span class="text-danger">*</span></label>
+                <input type="text" class="form-control" id="inputName" maxlength="100"
+                  placeholder="Build Competition: Gingerbread House - 2022 - 1st Place"
+                  value="<%= badge ? badge.name : '' %>">
+                <div class="form-text">Displayed as the main badge title. Max 100 characters.</div>
+              </div>
+
+              <div class="mb-3">
+                <label class="form-label fw-semibold">Description <span class="text-muted small fw-normal">(optional)</span></label>
+                <textarea class="form-control" id="inputDescription" rows="2"
+                  placeholder="Short description of how this badge is earned."><%= badge ? (badge.description || '') : '' %></textarea>
+              </div>
+
+              <div class="row">
+                <div class="col-md-6 mb-3">
+                  <label class="form-label fw-semibold">Minecraft Item Icon <span class="text-danger">*</span></label>
+                  <input type="text" class="form-control font-monospace" id="inputItemIcon"
+                    placeholder="golden_apple"
+                    value="<%= badge ? badge.itemIcon : '' %>">
+                  <div class="form-text">
+                    Minecraft material name (lowercase, underscores). e.g. <code>cake</code>, <code>diamond_sword</code>, <code>trophy</code>
+                  </div>
+                </div>
+                <div class="col-md-6 mb-3">
+                  <label class="form-label fw-semibold">Background Colour <span class="text-danger">*</span></label>
+                  <div class="input-group">
+                    <input type="color" class="form-control form-control-color" id="inputColorPicker"
+                      value="<%= badge ? badge.backgroundColor : '#1a1a2e' %>">
+                    <input type="text" class="form-control font-monospace" id="inputBackgroundColor"
+                      placeholder="#1a1a2e" maxlength="7"
+                      value="<%= badge ? badge.backgroundColor : '#1a1a2e' %>">
+                  </div>
+                  <div class="form-text">Hex colour for the badge background.</div>
+                </div>
+              </div>
+
+              <div class="mb-3">
+                <label class="form-label fw-semibold">LuckPerms Group <span class="text-muted small fw-normal">(optional)</span></label>
+                <input type="text" class="form-control font-monospace" id="inputLuckpermsGroup"
+                  placeholder="builder"
+                  value="<%= badge ? (badge.luckpermsGroup || '') : '' %>">
+                <div class="form-text">
+                  If set, users in this LuckPerms group will automatically receive this badge.
+                  Removing the group will revoke the badge (unless manually assigned).
+                </div>
+              </div>
+
+              <div class="d-flex gap-2 mt-4">
+                <button type="button" class="btn btn-primary" id="btnSave">
+                  <i class="fa-solid fa-floppy-disk me-1"></i><%= badge ? 'Save Changes' : 'Create Badge' %>
+                </button>
+                <a href="/dashboard/badges" class="btn btn-outline-secondary">Cancel</a>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Live preview -->
+        <div class="col-lg-5">
+          <div class="card shadow-sm">
+            <div class="card-body p-4">
+              <h6 class="text-muted text-uppercase mb-3">Live Preview</h6>
+              <div class="mc-badge-toast" id="badgePreview" style="background-color: <%= badge ? badge.backgroundColor : '#1a1a2e' %>;">
+                <img
+                  src="https://mc.nerobot.ru/img/items/<%= badge ? badge.itemIcon : 'grass_block' %>.png"
+                  alt="icon"
+                  class="mc-badge-icon"
+                  id="previewIcon"
+                  onerror="this.src='/images/siteLogo.png'"
+                >
+                <div class="mc-badge-text">
+                  <span class="mc-badge-achievement">Achievement Unlocked</span>
+                  <span class="mc-badge-name" id="previewName"><%= badge ? badge.name : 'Badge Name' %></span>
+                </div>
+              </div>
+              <p class="text-muted small mt-2 mb-0">
+                This is how the badge will appear on profiles and in Discord.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div><!-- /.wrap -->
+  </div><!-- /#wpbody-content -->
+  <%- include("../../admin/_footer.ejs") %>
+</div><!-- /#wpcontent -->
+
+<style>
+.mc-badge-toast {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 4px;
+  border: 2px solid rgba(255,255,255,0.15);
+  min-height: 60px;
+}
+.mc-badge-icon {
+  width: 44px;
+  height: 44px;
+  image-rendering: pixelated;
+  flex-shrink: 0;
+}
+.mc-badge-text {
+  display: flex;
+  flex-direction: column;
+}
+.mc-badge-achievement {
+  font-size: 10px;
+  color: rgba(255,255,255,0.65);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.mc-badge-name {
+  font-size: 15px;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 1px 1px 2px rgba(0,0,0,0.8);
+  line-height: 1.3;
+}
+</style>
+
+<script>
+const badgeId = <%= badge ? badge.badgeId : 'null' %>;
+
+// Sync colour picker ↔ text input
+document.getElementById('inputColorPicker').addEventListener('input', e => {
+  document.getElementById('inputBackgroundColor').value = e.target.value;
+  updatePreview();
+});
+document.getElementById('inputBackgroundColor').addEventListener('input', e => {
+  if (/^#[0-9A-Fa-f]{6}$/.test(e.target.value)) {
+    document.getElementById('inputColorPicker').value = e.target.value;
+  }
+  updatePreview();
+});
+
+document.getElementById('inputName').addEventListener('input', updatePreview);
+document.getElementById('inputItemIcon').addEventListener('input', () => {
+  updatePreview();
+  const icon = document.getElementById('inputItemIcon').value.trim().toLowerCase();
+  if (icon) {
+    const img = document.getElementById('previewIcon');
+    img.src = `https://mc.nerobot.ru/img/items/${icon}.png`;
+  }
+});
+
+function updatePreview() {
+  const name = document.getElementById('inputName').value.trim() || 'Badge Name';
+  const color = document.getElementById('inputBackgroundColor').value.trim() || '#1a1a2e';
+  document.getElementById('previewName').textContent = name;
+  document.getElementById('badgePreview').style.backgroundColor = color;
+}
+
+document.getElementById('btnSave').addEventListener('click', async () => {
+  const errEl = document.getElementById('formError');
+  const okEl = document.getElementById('formSuccess');
+  errEl.classList.add('d-none');
+  okEl.classList.add('d-none');
+
+  const payload = {
+    name: document.getElementById('inputName').value.trim(),
+    description: document.getElementById('inputDescription').value.trim() || null,
+    itemIcon: document.getElementById('inputItemIcon').value.trim().toLowerCase(),
+    backgroundColor: document.getElementById('inputBackgroundColor').value.trim(),
+    luckpermsGroup: document.getElementById('inputLuckpermsGroup').value.trim() || null,
+  };
+
+  const method = badgeId ? 'PUT' : 'POST';
+  const url = badgeId ? `/dashboard/badges/${badgeId}` : '/dashboard/badges';
+
+  const r = await fetch(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  const data = await r.json();
+
+  if (data.success) {
+    if (badgeId) {
+      okEl.textContent = 'Badge saved successfully.';
+      okEl.classList.remove('d-none');
+    } else {
+      window.location.href = `/dashboard/badges/${data.data.badgeId}/edit`;
+    }
+  } else {
+    errEl.textContent = data.message || 'Failed to save badge.';
+    errEl.classList.remove('d-none');
+  }
+});
+</script>

--- a/views/dashboard/badges/edit.ejs
+++ b/views/dashboard/badges/edit.ejs
@@ -40,16 +40,6 @@
                   placeholder="Short description of how this badge is earned."><%= badge ? (badge.description || '') : '' %></textarea>
               </div>
 
-              <div class="mb-3">
-                <label class="form-label fw-semibold">Minecraft Item Icon <span class="text-danger">*</span></label>
-                <input type="text" class="form-control font-monospace" id="inputItemIcon"
-                  placeholder="golden_apple"
-                  value="<%= badge ? badge.itemIcon : '' %>">
-                <div class="form-text">
-                  Minecraft material name (lowercase, underscores). e.g. <code>cake</code>, <code>diamond_sword</code>, <code>grass_block</code>
-                </div>
-              </div>
-
               <div class="row">
                 <div class="col-md-6 mb-3">
                   <label class="form-label fw-semibold">Background Colour <span class="text-danger">*</span></label>
@@ -100,13 +90,6 @@
               <h6 class="text-muted text-uppercase mb-3">Live Preview</h6>
               <div class="mc-badge-toast" id="badgePreview"
                 style="background-color: <%= badge ? badge.backgroundColor : '#1a1a2e' %>;">
-                <img
-                  src="https://mc.nerobot.ru/img/items/<%= badge ? badge.itemIcon : 'grass_block' %>.png"
-                  alt="icon"
-                  class="mc-badge-icon"
-                  id="previewIcon"
-                  onerror="this.src='/images/siteLogo.png'"
-                >
                 <div class="mc-badge-text">
                   <span class="mc-badge-achievement" id="previewAchievement"
                     style="color: <%= badge ? badge.textColor + 'aa' : 'rgba(255,255,255,0.65)' %>;">
@@ -148,12 +131,6 @@
   border-radius: 4px;
   border: 2px solid rgba(255,255,255,0.15);
   min-height: 60px;
-}
-.mc-badge-icon {
-  width: 44px;
-  height: 44px;
-  image-rendering: pixelated;
-  flex-shrink: 0;
 }
 .mc-badge-text { display: flex; flex-direction: column; }
 .mc-badge-achievement {
@@ -233,13 +210,6 @@ document.getElementById('inputTextColor').addEventListener('input', e => {
 
 document.getElementById('inputName').addEventListener('input', updatePreview);
 document.getElementById('inputDescription').addEventListener('input', updatePreview);
-document.getElementById('inputItemIcon').addEventListener('input', () => {
-  updatePreview();
-  const icon = document.getElementById('inputItemIcon').value.trim().toLowerCase();
-  if (icon) {
-    document.getElementById('previewIcon').src = `https://mc.nerobot.ru/img/items/${icon}.png`;
-  }
-});
 
 document.getElementById('btnSave').addEventListener('click', async () => {
   const errEl = document.getElementById('formError');
@@ -250,7 +220,6 @@ document.getElementById('btnSave').addEventListener('click', async () => {
   const payload = {
     name:            document.getElementById('inputName').value.trim(),
     description:     document.getElementById('inputDescription').value.trim() || null,
-    itemIcon:        document.getElementById('inputItemIcon').value.trim().toLowerCase(),
     backgroundColor: document.getElementById('inputBackgroundColor').value.trim(),
     textColor:       document.getElementById('inputTextColor').value.trim(),
     luckpermsGroup:  document.getElementById('inputLuckpermsGroup').value.trim() || null,

--- a/views/dashboard/badges/edit.ejs
+++ b/views/dashboard/badges/edit.ejs
@@ -40,16 +40,17 @@
                   placeholder="Short description of how this badge is earned."><%= badge ? (badge.description || '') : '' %></textarea>
               </div>
 
-              <div class="row">
-                <div class="col-md-6 mb-3">
-                  <label class="form-label fw-semibold">Minecraft Item Icon <span class="text-danger">*</span></label>
-                  <input type="text" class="form-control font-monospace" id="inputItemIcon"
-                    placeholder="golden_apple"
-                    value="<%= badge ? badge.itemIcon : '' %>">
-                  <div class="form-text">
-                    Minecraft material name (lowercase, underscores). e.g. <code>cake</code>, <code>diamond_sword</code>, <code>trophy</code>
-                  </div>
+              <div class="mb-3">
+                <label class="form-label fw-semibold">Minecraft Item Icon <span class="text-danger">*</span></label>
+                <input type="text" class="form-control font-monospace" id="inputItemIcon"
+                  placeholder="golden_apple"
+                  value="<%= badge ? badge.itemIcon : '' %>">
+                <div class="form-text">
+                  Minecraft material name (lowercase, underscores). e.g. <code>cake</code>, <code>diamond_sword</code>, <code>grass_block</code>
                 </div>
+              </div>
+
+              <div class="row">
                 <div class="col-md-6 mb-3">
                   <label class="form-label fw-semibold">Background Colour <span class="text-danger">*</span></label>
                   <div class="input-group">
@@ -59,7 +60,16 @@
                       placeholder="#1a1a2e" maxlength="7"
                       value="<%= badge ? badge.backgroundColor : '#1a1a2e' %>">
                   </div>
-                  <div class="form-text">Hex colour for the badge background.</div>
+                </div>
+                <div class="col-md-6 mb-3">
+                  <label class="form-label fw-semibold">Text Colour <span class="text-danger">*</span></label>
+                  <div class="input-group">
+                    <input type="color" class="form-control form-control-color" id="inputTextColorPicker"
+                      value="<%= badge ? badge.textColor : '#ffffff' %>">
+                    <input type="text" class="form-control font-monospace" id="inputTextColor"
+                      placeholder="#ffffff" maxlength="7"
+                      value="<%= badge ? badge.textColor : '#ffffff' %>">
+                  </div>
                 </div>
               </div>
 
@@ -69,8 +79,7 @@
                   placeholder="builder"
                   value="<%= badge ? (badge.luckpermsGroup || '') : '' %>">
                 <div class="form-text">
-                  If set, users in this LuckPerms group will automatically receive this badge.
-                  Removing the group will revoke the badge (unless manually assigned).
+                  Users in this LuckPerms group automatically receive this badge. Losing the group revokes it unless manually assigned.
                 </div>
               </div>
 
@@ -89,7 +98,8 @@
           <div class="card shadow-sm">
             <div class="card-body p-4">
               <h6 class="text-muted text-uppercase mb-3">Live Preview</h6>
-              <div class="mc-badge-toast" id="badgePreview" style="background-color: <%= badge ? badge.backgroundColor : '#1a1a2e' %>;">
+              <div class="mc-badge-toast" id="badgePreview"
+                style="background-color: <%= badge ? badge.backgroundColor : '#1a1a2e' %>;">
                 <img
                   src="https://mc.nerobot.ru/img/items/<%= badge ? badge.itemIcon : 'grass_block' %>.png"
                   alt="icon"
@@ -98,8 +108,22 @@
                   onerror="this.src='/images/siteLogo.png'"
                 >
                 <div class="mc-badge-text">
-                  <span class="mc-badge-achievement">Achievement Unlocked</span>
-                  <span class="mc-badge-name" id="previewName"><%= badge ? badge.name : 'Badge Name' %></span>
+                  <span class="mc-badge-achievement" id="previewAchievement"
+                    style="color: <%= badge ? badge.textColor + 'aa' : 'rgba(255,255,255,0.65)' %>;">
+                    Achievement Unlocked
+                  </span>
+                  <span class="mc-badge-name" id="previewName"
+                    style="color: <%= badge ? badge.textColor : '#ffffff' %>;">
+                    <%= badge ? badge.name : 'Badge Name' %>
+                  </span>
+                  <% if (badge && badge.description) { %>
+                    <span class="mc-badge-desc" id="previewDesc"
+                      style="color: <%= badge.textColor + 'cc' %>;">
+                      <%= badge.description %>
+                    </span>
+                  <% } else { %>
+                    <span class="mc-badge-desc d-none" id="previewDesc"></span>
+                  <% } %>
                 </div>
               </div>
               <p class="text-muted small mt-2 mb-0">
@@ -131,29 +155,59 @@
   image-rendering: pixelated;
   flex-shrink: 0;
 }
-.mc-badge-text {
-  display: flex;
-  flex-direction: column;
-}
+.mc-badge-text { display: flex; flex-direction: column; }
 .mc-badge-achievement {
   font-size: 10px;
-  color: rgba(255,255,255,0.65);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 .mc-badge-name {
   font-size: 15px;
   font-weight: 700;
-  color: #fff;
-  text-shadow: 1px 1px 2px rgba(0,0,0,0.8);
+  text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
   line-height: 1.3;
+}
+.mc-badge-desc {
+  font-size: 11px;
+  opacity: 0.85;
+  margin-top: 2px;
 }
 </style>
 
 <script>
 const badgeId = <%= badge ? badge.badgeId : 'null' %>;
 
-// Sync colour picker ↔ text input
+function hexWithAlpha(hex, alpha) {
+  const r = parseInt(hex.slice(1,3),16);
+  const g = parseInt(hex.slice(3,5),16);
+  const b = parseInt(hex.slice(5,7),16);
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+
+function updatePreview() {
+  const name = document.getElementById('inputName').value.trim() || 'Badge Name';
+  const desc = document.getElementById('inputDescription').value.trim();
+  const bg   = document.getElementById('inputBackgroundColor').value.trim() || '#1a1a2e';
+  const tc   = document.getElementById('inputTextColor').value.trim() || '#ffffff';
+
+  document.getElementById('previewName').textContent = name;
+  document.getElementById('previewName').style.color = tc;
+  document.getElementById('badgePreview').style.backgroundColor = bg;
+
+  const achieveEl = document.getElementById('previewAchievement');
+  achieveEl.style.color = hexWithAlpha(tc, 0.65);
+
+  const descEl = document.getElementById('previewDesc');
+  if (desc) {
+    descEl.textContent = desc;
+    descEl.style.color = hexWithAlpha(tc, 0.8);
+    descEl.classList.remove('d-none');
+  } else {
+    descEl.classList.add('d-none');
+  }
+}
+
+// Background colour
 document.getElementById('inputColorPicker').addEventListener('input', e => {
   document.getElementById('inputBackgroundColor').value = e.target.value;
   updatePreview();
@@ -165,41 +219,47 @@ document.getElementById('inputBackgroundColor').addEventListener('input', e => {
   updatePreview();
 });
 
+// Text colour
+document.getElementById('inputTextColorPicker').addEventListener('input', e => {
+  document.getElementById('inputTextColor').value = e.target.value;
+  updatePreview();
+});
+document.getElementById('inputTextColor').addEventListener('input', e => {
+  if (/^#[0-9A-Fa-f]{6}$/.test(e.target.value)) {
+    document.getElementById('inputTextColorPicker').value = e.target.value;
+  }
+  updatePreview();
+});
+
 document.getElementById('inputName').addEventListener('input', updatePreview);
+document.getElementById('inputDescription').addEventListener('input', updatePreview);
 document.getElementById('inputItemIcon').addEventListener('input', () => {
   updatePreview();
   const icon = document.getElementById('inputItemIcon').value.trim().toLowerCase();
   if (icon) {
-    const img = document.getElementById('previewIcon');
-    img.src = `https://mc.nerobot.ru/img/items/${icon}.png`;
+    document.getElementById('previewIcon').src = `https://mc.nerobot.ru/img/items/${icon}.png`;
   }
 });
 
-function updatePreview() {
-  const name = document.getElementById('inputName').value.trim() || 'Badge Name';
-  const color = document.getElementById('inputBackgroundColor').value.trim() || '#1a1a2e';
-  document.getElementById('previewName').textContent = name;
-  document.getElementById('badgePreview').style.backgroundColor = color;
-}
-
 document.getElementById('btnSave').addEventListener('click', async () => {
   const errEl = document.getElementById('formError');
-  const okEl = document.getElementById('formSuccess');
+  const okEl  = document.getElementById('formSuccess');
   errEl.classList.add('d-none');
   okEl.classList.add('d-none');
 
   const payload = {
-    name: document.getElementById('inputName').value.trim(),
-    description: document.getElementById('inputDescription').value.trim() || null,
-    itemIcon: document.getElementById('inputItemIcon').value.trim().toLowerCase(),
+    name:            document.getElementById('inputName').value.trim(),
+    description:     document.getElementById('inputDescription').value.trim() || null,
+    itemIcon:        document.getElementById('inputItemIcon').value.trim().toLowerCase(),
     backgroundColor: document.getElementById('inputBackgroundColor').value.trim(),
-    luckpermsGroup: document.getElementById('inputLuckpermsGroup').value.trim() || null,
+    textColor:       document.getElementById('inputTextColor').value.trim(),
+    luckpermsGroup:  document.getElementById('inputLuckpermsGroup').value.trim() || null,
   };
 
   const method = badgeId ? 'PUT' : 'POST';
-  const url = badgeId ? `/dashboard/badges/${badgeId}` : '/dashboard/badges';
+  const url    = badgeId ? `/dashboard/badges/${badgeId}` : '/dashboard/badges';
 
-  const r = await fetch(url, {
+  const r    = await fetch(url, {
     method,
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),

--- a/views/dashboard/badges/index.ejs
+++ b/views/dashboard/badges/index.ejs
@@ -1,0 +1,191 @@
+<%- include("../../admin/_head.ejs", { pageTitle }) %>
+<%- include("../../admin/_topbar.ejs") %>
+<%- include("../../admin/_sidebar.ejs") %>
+
+<div id="wpcontent">
+  <div id="wpbody-content">
+    <div class="wrap">
+
+      <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2"><i class="fa-solid fa-award me-2"></i>Badges</h1>
+        <div class="btn-toolbar mb-2 mb-md-0 gap-2">
+          <a href="/dashboard/badges/create" class="btn btn-sm btn-primary">
+            <i class="fa-solid fa-plus me-1"></i>Create Badge
+          </a>
+        </div>
+      </div>
+
+      <%- include("../../admin/_notices.ejs") %>
+
+      <% if (!badgesData.success || !badgesData.data || !badgesData.data.length) { %>
+        <div class="alert alert-info">
+          No badges configured yet. <a href="/dashboard/badges/create">Create your first badge</a>.
+        </div>
+      <% } else { %>
+        <div class="row g-3 mb-4">
+          <% badgesData.data.forEach(function(badge) { %>
+            <div class="col-12 col-sm-6 col-xl-4">
+              <div class="card shadow-sm h-100">
+                <div class="card-body">
+                  <!-- Minecraft-style achievement toast preview -->
+                  <div class="mc-badge-toast mb-3" style="background-color: <%= badge.backgroundColor %>;">
+                    <img
+                      src="https://mc.nerobot.ru/img/items/<%= badge.itemIcon %>.png"
+                      alt="<%= badge.itemIcon %>"
+                      class="mc-badge-icon"
+                      onerror="this.src='/images/siteLogo.png'"
+                    >
+                    <div class="mc-badge-text">
+                      <span class="mc-badge-achievement">Achievement Unlocked</span>
+                      <span class="mc-badge-name"><%= badge.name %></span>
+                    </div>
+                  </div>
+
+                  <% if (badge.description) { %>
+                    <p class="text-muted small mb-2"><%= badge.description %></p>
+                  <% } %>
+
+                  <div class="d-flex flex-wrap gap-1 mb-3">
+                    <span class="badge text-bg-secondary font-monospace"><%= badge.itemIcon %></span>
+                    <span class="badge" style="background-color:<%= badge.backgroundColor %>;color:#fff;">
+                      <%= badge.backgroundColor %>
+                    </span>
+                    <% if (badge.luckpermsGroup) { %>
+                      <span class="badge text-bg-info">LP: <%= badge.luckpermsGroup %></span>
+                    <% } %>
+                  </div>
+
+                  <div class="d-flex gap-2 flex-wrap">
+                    <a href="/dashboard/badges/<%= badge.badgeId %>/edit" class="btn btn-sm btn-warning">
+                      <i class="fa-solid fa-pen me-1"></i>Edit
+                    </a>
+                    <a href="/dashboard/badges/<%= badge.badgeId %>/assign" class="btn btn-sm btn-success">
+                      <i class="fa-solid fa-user-plus me-1"></i>Assign
+                    </a>
+                    <button class="btn btn-sm btn-outline-secondary btn-duplicate"
+                      data-id="<%= badge.badgeId %>"
+                      data-name="<%= badge.name %>">
+                      <i class="fa-solid fa-copy me-1"></i>Duplicate
+                    </button>
+                    <button class="btn btn-sm btn-danger btn-delete"
+                      data-id="<%= badge.badgeId %>"
+                      data-name="<%= badge.name %>">
+                      <i class="fa-solid fa-trash me-1"></i>Delete
+                    </button>
+                  </div>
+                </div>
+                <div class="card-footer text-muted small">
+                  ID #<%= badge.badgeId %> &middot; Created <%= new Date(badge.createdAt).toLocaleDateString() %>
+                </div>
+              </div>
+            </div>
+          <% }) %>
+        </div>
+      <% } %>
+
+    </div><!-- /.wrap -->
+  </div><!-- /#wpbody-content -->
+
+<!-- Delete Badge Modal -->
+<div class="modal fade" id="deleteBadgeModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Delete Badge</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <p>Are you sure you want to delete <strong id="deleteBadgeName"></strong>?</p>
+        <p class="text-muted small">This will remove the badge from all users who have earned it.</p>
+        <div id="deleteBadgeError" class="alert alert-danger d-none"></div>
+      </div>
+      <div class="modal-footer">
+        <input type="hidden" id="deleteBadgeId">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-danger" id="deleteBadgeConfirm">Delete</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+  <%- include("../../admin/_footer.ejs") %>
+</div><!-- /#wpcontent -->
+
+<style>
+.mc-badge-toast {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  border: 2px solid rgba(255,255,255,0.15);
+  min-height: 56px;
+}
+.mc-badge-icon {
+  width: 40px;
+  height: 40px;
+  image-rendering: pixelated;
+  flex-shrink: 0;
+}
+.mc-badge-text {
+  display: flex;
+  flex-direction: column;
+}
+.mc-badge-achievement {
+  font-size: 10px;
+  color: rgba(255,255,255,0.65);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.mc-badge-name {
+  font-size: 14px;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 1px 1px 2px rgba(0,0,0,0.8);
+  line-height: 1.2;
+}
+</style>
+
+<script>
+// Delete modal
+document.querySelectorAll('.btn-delete').forEach(btn => {
+  btn.addEventListener('click', () => {
+    document.getElementById('deleteBadgeId').value = btn.dataset.id;
+    document.getElementById('deleteBadgeName').textContent = btn.dataset.name;
+    document.getElementById('deleteBadgeError').classList.add('d-none');
+    new bootstrap.Modal(document.getElementById('deleteBadgeModal')).show();
+  });
+});
+
+document.getElementById('deleteBadgeConfirm').addEventListener('click', async () => {
+  const id = document.getElementById('deleteBadgeId').value;
+  const errEl = document.getElementById('deleteBadgeError');
+  errEl.classList.add('d-none');
+
+  const r = await fetch(`/dashboard/badges/${id}`, { method: 'DELETE' });
+  const data = await r.json();
+
+  if (data.success) {
+    location.reload();
+  } else {
+    errEl.textContent = data.message || 'Failed to delete badge.';
+    errEl.classList.remove('d-none');
+  }
+});
+
+// Duplicate
+document.querySelectorAll('.btn-duplicate').forEach(btn => {
+  btn.addEventListener('click', async () => {
+    if (!confirm(`Duplicate badge "${btn.dataset.name}"?`)) return;
+
+    const r = await fetch(`/dashboard/badges/${btn.dataset.id}/duplicate`, { method: 'POST' });
+    const data = await r.json();
+
+    if (data.success) {
+      location.reload();
+    } else {
+      alert(data.message || 'Failed to duplicate badge.');
+    }
+  });
+});
+</script>

--- a/views/dashboard/badges/index.ejs
+++ b/views/dashboard/badges/index.ejs
@@ -36,8 +36,11 @@
                       onerror="this.src='/images/siteLogo.png'"
                     >
                     <div class="mc-badge-text">
-                      <span class="mc-badge-achievement">Achievement Unlocked</span>
-                      <span class="mc-badge-name"><%= badge.name %></span>
+                      <span class="mc-badge-achievement" style="color: <%= badge.textColor %>88;">Achievement Unlocked</span>
+                      <span class="mc-badge-name" style="color: <%= badge.textColor %>;"><%= badge.name %></span>
+                      <% if (badge.description) { %>
+                        <span class="mc-badge-desc" style="color: <%= badge.textColor %>cc;"><%= badge.description %></span>
+                      <% } %>
                     </div>
                   </div>
 
@@ -133,16 +136,19 @@
 }
 .mc-badge-achievement {
   font-size: 10px;
-  color: rgba(255,255,255,0.65);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 .mc-badge-name {
   font-size: 14px;
   font-weight: 700;
-  color: #fff;
-  text-shadow: 1px 1px 2px rgba(0,0,0,0.8);
+  text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
   line-height: 1.2;
+}
+.mc-badge-desc {
+  font-size: 11px;
+  opacity: 0.85;
+  margin-top: 2px;
 }
 </style>
 

--- a/views/dashboard/badges/index.ejs
+++ b/views/dashboard/badges/index.ejs
@@ -29,12 +29,6 @@
                 <div class="card-body">
                   <!-- Minecraft-style achievement toast preview -->
                   <div class="mc-badge-toast mb-3" style="background-color: <%= badge.backgroundColor %>;">
-                    <img
-                      src="https://mc.nerobot.ru/img/items/<%= badge.itemIcon %>.png"
-                      alt="<%= badge.itemIcon %>"
-                      class="mc-badge-icon"
-                      onerror="this.src='/images/siteLogo.png'"
-                    >
                     <div class="mc-badge-text">
                       <span class="mc-badge-achievement" style="color: <%= badge.textColor %>88;">Achievement Unlocked</span>
                       <span class="mc-badge-name" style="color: <%= badge.textColor %>;"><%= badge.name %></span>
@@ -49,7 +43,6 @@
                   <% } %>
 
                   <div class="d-flex flex-wrap gap-1 mb-3">
-                    <span class="badge text-bg-secondary font-monospace"><%= badge.itemIcon %></span>
                     <span class="badge" style="background-color:<%= badge.backgroundColor %>;color:#fff;">
                       <%= badge.backgroundColor %>
                     </span>
@@ -123,12 +116,6 @@
   border-radius: 4px;
   border: 2px solid rgba(255,255,255,0.15);
   min-height: 56px;
-}
-.mc-badge-icon {
-  width: 40px;
-  height: 40px;
-  image-rendering: pixelated;
-  flex-shrink: 0;
 }
 .mc-badge-text {
   display: flex;

--- a/views/dashboard/ranks/index.ejs
+++ b/views/dashboard/ranks/index.ejs
@@ -113,15 +113,20 @@
                       <form id="rankUserLookupForm" class="row g-3 align-items-end">
                         <div class="col-md-6">
                           <label for="rankLookupUsername" class="form-label">Minecraft username</label>
-                          <input
-                            type="text"
-                            class="form-control"
-                            id="rankLookupUsername"
-                            name="username"
-                            placeholder="Enter a username"
-                            autocomplete="off"
-                            required
-                          >
+                          <div class="position-relative">
+                            <input
+                              type="text"
+                              class="form-control"
+                              id="rankLookupUsername"
+                              name="username"
+                              placeholder="Start typing a username…"
+                              autocomplete="off"
+                              required
+                            >
+                            <div id="rankLookupSuggestions"
+                              class="list-group position-absolute w-100 shadow-sm"
+                              style="z-index:1000;display:none;max-height:220px;overflow-y:auto;top:100%;"></div>
+                          </div>
                         </div>
                         <div class="col-md-auto">
                           <button type="submit" class="btn btn-primary">Load profile</button>
@@ -748,6 +753,64 @@
         if (!silent) showLookupFeedback('danger', 'An unexpected error occurred while loading the player.');
       }
     }
+
+    // Username autocomplete
+    (function () {
+      const searchEl = document.getElementById('rankLookupUsername');
+      const suggestEl = document.getElementById('rankLookupSuggestions');
+      let searchTimer = null;
+
+      function clearSuggestions() {
+        suggestEl.innerHTML = '';
+        suggestEl.style.display = 'none';
+      }
+
+      function renderSuggestions(results) {
+        clearSuggestions();
+        if (!results.length) return;
+        results.forEach(user => {
+          const btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'list-group-item list-group-item-action d-flex align-items-center gap-2 py-1 px-2';
+          if (user.avatarUrl) {
+            const img = document.createElement('img');
+            img.src = user.avatarUrl;
+            img.alt = '';
+            img.width = 28; img.height = 28;
+            img.className = 'rounded';
+            btn.appendChild(img);
+          }
+          const span = document.createElement('span');
+          span.textContent = user.username;
+          span.className = 'flex-fill text-start small';
+          btn.appendChild(span);
+          btn.addEventListener('click', () => {
+            searchEl.value = user.username;
+            clearSuggestions();
+            loadUser(user.username);
+          });
+          suggestEl.appendChild(btn);
+        });
+        suggestEl.style.display = 'block';
+      }
+
+      searchEl.addEventListener('input', e => {
+        const q = e.target.value.trim();
+        clearTimeout(searchTimer);
+        if (q.length < 2) { clearSuggestions(); return; }
+        searchTimer = setTimeout(async () => {
+          try {
+            const r = await fetch(`/dashboard/ranks/user-search?q=${encodeURIComponent(q)}`);
+            const data = await r.json();
+            renderSuggestions(data.results || []);
+          } catch { clearSuggestions(); }
+        }, 200);
+      });
+
+      document.addEventListener('click', e => {
+        if (!searchEl.contains(e.target) && !suggestEl.contains(e.target)) clearSuggestions();
+      });
+    })();
 
     if (lookupForm) {
       lookupForm.addEventListener('submit', (event) => {

--- a/views/modules/profile/badgeCard.ejs
+++ b/views/modules/profile/badgeCard.ejs
@@ -1,0 +1,20 @@
+<%
+  /**
+   * badgeCard.ejs — Minecraft-style achievement toast for a single badge.
+   *
+   * Expected locals:
+   *   badge  – badge object { name, itemIcon, backgroundColor, description, earnedAt }
+   */
+%>
+<div class="mc-badge-card" style="background-color: <%= badge.backgroundColor %>;" title="<%= badge.description || badge.name %>">
+  <img
+    src="https://mc.nerobot.ru/img/items/<%= badge.itemIcon %>.png"
+    alt="<%= badge.itemIcon %>"
+    class="mc-badge-card-icon"
+    onerror="this.src='/images/siteLogo.png'"
+  >
+  <div class="mc-badge-card-text">
+    <span class="mc-badge-card-label">Achievement Unlocked</span>
+    <span class="mc-badge-card-name"><%= badge.name %></span>
+  </div>
+</div>

--- a/views/modules/profile/badgeCard.ejs
+++ b/views/modules/profile/badgeCard.ejs
@@ -3,10 +3,12 @@
    * badgeCard.ejs — Minecraft-style achievement toast for a single badge.
    *
    * Expected locals:
-   *   badge  – badge object { name, itemIcon, backgroundColor, description, earnedAt }
+   *   badge  – { name, description, itemIcon, backgroundColor, textColor, earnedAt }
    */
+  const tc = badge.textColor || '#ffffff';
 %>
-<div class="mc-badge-card" style="background-color: <%= badge.backgroundColor %>;" title="<%= badge.description || badge.name %>">
+<div class="mc-badge-card" style="background-color: <%= badge.backgroundColor %>;"
+     title="<%= badge.description ? badge.description : badge.name %>">
   <img
     src="https://mc.nerobot.ru/img/items/<%= badge.itemIcon %>.png"
     alt="<%= badge.itemIcon %>"
@@ -14,7 +16,10 @@
     onerror="this.src='/images/siteLogo.png'"
   >
   <div class="mc-badge-card-text">
-    <span class="mc-badge-card-label">Achievement Unlocked</span>
-    <span class="mc-badge-card-name"><%= badge.name %></span>
+    <span class="mc-badge-card-label" style="color: <%= tc %>88;">Achievement Unlocked</span>
+    <span class="mc-badge-card-name" style="color: <%= tc %>;"><%= badge.name %></span>
+    <% if (badge.description) { %>
+      <span class="mc-badge-card-desc" style="color: <%= tc %>cc;"><%= badge.description %></span>
+    <% } %>
   </div>
 </div>

--- a/views/modules/profile/badgeCard.ejs
+++ b/views/modules/profile/badgeCard.ejs
@@ -3,18 +3,12 @@
    * badgeCard.ejs — Minecraft-style achievement toast for a single badge.
    *
    * Expected locals:
-   *   badge  – { name, description, itemIcon, backgroundColor, textColor, earnedAt }
+   *   badge  – { name, description, backgroundColor, textColor, earnedAt }
    */
   const tc = badge.textColor || '#ffffff';
 %>
 <div class="mc-badge-card" style="background-color: <%= badge.backgroundColor %>;"
      title="<%= badge.description ? badge.description : badge.name %>">
-  <img
-    src="https://mc.nerobot.ru/img/items/<%= badge.itemIcon %>.png"
-    alt="<%= badge.itemIcon %>"
-    class="mc-badge-card-icon"
-    onerror="this.src='/images/siteLogo.png'"
-  >
   <div class="mc-badge-card-text">
     <span class="mc-badge-card-label" style="color: <%= tc %>88;">Achievement Unlocked</span>
     <span class="mc-badge-card-name" style="color: <%= tc %>;"><%= badge.name %></span>

--- a/views/modules/profile/profile.ejs
+++ b/views/modules/profile/profile.ejs
@@ -452,12 +452,6 @@
     transform: translateY(-2px);
     box-shadow: 0 4px 16px rgba(0,0,0,0.25);
 }
-.mc-badge-card-icon {
-    width: 40px;
-    height: 40px;
-    image-rendering: pixelated;
-    flex-shrink: 0;
-}
 .mc-badge-card-text {
     display: flex;
     flex-direction: column;

--- a/views/modules/profile/profile.ejs
+++ b/views/modules/profile/profile.ejs
@@ -53,6 +53,14 @@
                                 </a>
                             </li>
                         <% } %>
+                        <% if (profileBadges && profileBadges.length > 0) { %>
+                            <li class="nav-item" role="presentation">
+                                <a class="nav-link profile-tab-link" id="badges-tab" data-bs-toggle="tab" href="#badges" role="tab" aria-controls="badges" aria-selected="false">
+                                    <i class="fa-solid fa-award me-2"></i>Badges
+                                    <span class="badge text-bg-secondary ms-1"><%= profileBadges.length %></span>
+                                </a>
+                            </li>
+                        <% } %>
                     </ul>
 
                     <div class="tab-content pt-4" id="profileTabsContent">
@@ -333,6 +341,18 @@
                                 </div>
                             </div>
                         <% } %>
+
+                        <% if (profileBadges && profileBadges.length > 0) { %>
+                            <div class="tab-pane fade" id="badges" role="tabpanel" aria-labelledby="badges-tab">
+                                <div class="row g-3">
+                                    <% profileBadges.forEach(function(badge) { %>
+                                        <div class="col-12 col-sm-6">
+                                            <%- include("../../modules/profile/badgeCard.ejs", { badge: badge }) %>
+                                        </div>
+                                    <% }) %>
+                                </div>
+                            </div>
+                        <% } %>
                     </div>
                 </div>
             </div>
@@ -413,5 +433,47 @@
         </div>
     </div>
 </div>
+
+<style>
+.mc-badge-card {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    border-radius: 6px;
+    border: 2px solid rgba(255,255,255,0.12);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.mc-badge-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 16px rgba(0,0,0,0.25);
+}
+.mc-badge-card-icon {
+    width: 40px;
+    height: 40px;
+    image-rendering: pixelated;
+    flex-shrink: 0;
+}
+.mc-badge-card-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+.mc-badge-card-label {
+    font-size: 10px;
+    color: rgba(255,255,255,0.6);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+.mc-badge-card-name {
+    font-size: 13px;
+    font-weight: 700;
+    color: #fff;
+    text-shadow: 1px 1px 2px rgba(0,0,0,0.7);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+</style>
 
 <%- include("../../modules/footer.ejs") %>

--- a/views/modules/profile/profile.ejs
+++ b/views/modules/profile/profile.ejs
@@ -53,14 +53,14 @@
                                 </a>
                             </li>
                         <% } %>
-                        <% if (profileBadges && profileBadges.length > 0) { %>
-                            <li class="nav-item" role="presentation">
-                                <a class="nav-link profile-tab-link" id="badges-tab" data-bs-toggle="tab" href="#badges" role="tab" aria-controls="badges" aria-selected="false">
-                                    <i class="fa-solid fa-award me-2"></i>Badges
+                        <li class="nav-item" role="presentation">
+                            <a class="nav-link profile-tab-link" id="badges-tab" data-bs-toggle="tab" href="#badges" role="tab" aria-controls="badges" aria-selected="false">
+                                <i class="fa-solid fa-award me-2"></i>Badges
+                                <% if (profileBadges && profileBadges.length > 0) { %>
                                     <span class="badge text-bg-secondary ms-1"><%= profileBadges.length %></span>
-                                </a>
-                            </li>
-                        <% } %>
+                                <% } %>
+                            </a>
+                        </li>
                     </ul>
 
                     <div class="tab-content pt-4" id="profileTabsContent">
@@ -342,8 +342,12 @@
                             </div>
                         <% } %>
 
-                        <% if (profileBadges && profileBadges.length > 0) { %>
-                            <div class="tab-pane fade" id="badges" role="tabpanel" aria-labelledby="badges-tab">
+                        <div class="tab-pane fade" id="badges" role="tabpanel" aria-labelledby="badges-tab">
+                            <% if (!profileBadges || profileBadges.length === 0) { %>
+                                <div class="alert alert-warning mb-0" role="alert">
+                                    <%= profileApiData.username %> hasn't earned any badges yet.
+                                </div>
+                            <% } else { %>
                                 <div class="row g-3">
                                     <% profileBadges.forEach(function(badge) { %>
                                         <div class="col-12 col-sm-6">
@@ -351,8 +355,8 @@
                                         </div>
                                     <% }) %>
                                 </div>
-                            </div>
-                        <% } %>
+                            <% } %>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -461,18 +465,23 @@
 }
 .mc-badge-card-label {
     font-size: 10px;
-    color: rgba(255,255,255,0.6);
     text-transform: uppercase;
     letter-spacing: 0.05em;
 }
 .mc-badge-card-name {
     font-size: 13px;
     font-weight: 700;
-    color: #fff;
-    text-shadow: 1px 1px 2px rgba(0,0,0,0.7);
+    text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+.mc-badge-card-desc {
+    font-size: 11px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    opacity: 0.85;
 }
 </style>
 


### PR DESCRIPTION
## Summary
Implements a complete badge system allowing administrators to create, manage, and assign badges to users. Badges are displayed on user profiles and can be automatically synced with LuckPerms groups.

## Key Changes

### Core Badge System
- **Badge Controller** (`controllers/badgeController.js`): CRUD operations for badges, user badge assignments, and LuckPerms group synchronization
- **Badge API Routes** (`api/routes/badges.js`): Public endpoint for fetching user badges and admin endpoints for badge management
- **Database Schema** (`prisma/schema.prisma`): New `badges` and `user_badges` tables with migrations

### Admin Dashboard
- **Badge Management UI** (`views/dashboard/badges/index.ejs`): List, create, edit, duplicate, and delete badges with Minecraft-style achievement toast previews
- **Badge Editor** (`views/dashboard/badges/edit.ejs`): Form to create/edit badges with live color preview and optional LuckPerms group linking
- **Badge Assignment UI** (`views/dashboard/badges/assign.ejs`): Separate panels to assign/remove badges from users with username autocomplete
- **Dashboard Routes** (`routes/dashboard/badges.js`): Session-authenticated routes for badge management pages and user search endpoint
- **Page Registry** (`admin/pageRegistry.js`): Added Badges menu item under Community section

### Profile Integration
- **Profile Display** (`views/modules/profile/profile.ejs`): New "Badges" tab showing user's earned badges
- **Badge Card Component** (`views/modules/profile/badgeCard.ejs`): Minecraft-style achievement toast rendering for individual badges
- **Profile Routes** (`routes/profileRoutes.js`): Fetch and pass badge data to profile view

### Automation
- **LuckPerms Sync Cron** (`cron/badgeLuckpermsSyncCron.js`): Runs every 15 minutes to automatically grant/revoke badges based on LuckPerms group membership
- **Discord Command** (`commands/profile.mjs`): Display top 5 badges in Discord profile command output

### Supporting Features
- **Username Autocomplete**: Added to both badge assignment and rank management forms for better UX
- **Rank Routes Enhancement** (`routes/dashboard/ranks.js`): Added user search endpoint for autocomplete functionality

## Notable Implementation Details
- Badges support customizable background and text colors with hex validation
- Manual badge assignments are preserved even if a user loses a linked LuckPerms group
- Automatic LuckPerms-linked badges are revoked when users lose the group (unless manually assigned)
- Minecraft-style achievement toast styling for consistent visual presentation across web and Discord
- Session-authenticated proxy routes forward badge operations to the API layer

https://claude.ai/code/session_01MK8WXCSJGqmU8GryuHDXKi