### PR TITLE
Support QuickShop-Hikari NBT item format with background indexing

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,6 +52,7 @@ import("./cron/unverifiedReminderCron.js");
 import("./cron/eventTemplateCron.js");
 import("./cron/announcementExpiryCron.js");
 import("./cron/badgeLuckpermsSyncCron.js");
+import("./cron/shopItemIndexCron.js");
 
 //
 // Website Related

--- a/cron/shopItemIndexCron.js
+++ b/cron/shopItemIndexCron.js
@@ -1,0 +1,82 @@
+import cron from "node-cron";
+import zlib from "zlib";
+import { quickshopDb } from "../controllers/databaseController.js";
+
+// Extract the Minecraft item ID from a base64+gzip-encoded NBT binary.
+// QuickShop-Hikari changed its storage format (around 2026-04-22, data id ~6000):
+// old format: item column = plain YAML text ("item:\n  id: minecraft:bow\n ...")
+// new format: item column = base64(gzip(NBT binary)) — same as the encoded column
+// The item ID is stored as a TAG_String with key "id" inside the NBT compound.
+function decodeNbtItemId(rawItem) {
+  try {
+    const buf = Buffer.from(rawItem, "base64");
+    const nbt = zlib.gunzipSync(buf);
+    // TAG_String = 0x08, followed by 2-byte key length, key bytes, 2-byte value length, value bytes
+    // We look for the sequence: 0x08 0x00 0x02 'i' 'd'
+    const pattern = Buffer.from([0x08, 0x00, 0x02, 0x69, 0x64]);
+    const idx = nbt.indexOf(pattern);
+    if (idx === -1) return null;
+    const valueLen = nbt.readUInt16BE(idx + 5);
+    const rawId = nbt.toString("utf8", idx + 7, idx + 7 + valueLen);
+    return rawId.replace("minecraft:", "");
+  } catch {
+    return null;
+  }
+}
+
+async function indexNewShopItems() {
+  return new Promise((resolve) => {
+    quickshopDb.query(
+      `SELECT id, item FROM qs_data WHERE item NOT LIKE 'item:%' AND name IS NULL LIMIT 500`,
+      (error, rows) => {
+        if (error) {
+          console.error("Shop item index query error:", error);
+          return resolve(0);
+        }
+        if (!rows || rows.length === 0) return resolve(0);
+
+        let completed = 0;
+        let indexed = 0;
+        const total = rows.length;
+
+        for (const row of rows) {
+          const itemId = decodeNbtItemId(row.item);
+          if (!itemId) {
+            // Mark as attempted with a placeholder so we don't retry forever
+            quickshopDb.query(
+              `UPDATE qs_data SET name = '' WHERE id = ? AND name IS NULL`,
+              [row.id],
+              () => { completed++; if (completed === total) resolve(indexed); }
+            );
+            continue;
+          }
+          quickshopDb.query(
+            `UPDATE qs_data SET name = ? WHERE id = ? AND name IS NULL`,
+            [itemId, row.id],
+            (err) => {
+              if (err) {
+                console.error(`Shop index update error for data id=${row.id}:`, err);
+              } else {
+                indexed++;
+              }
+              completed++;
+              if (completed === total) resolve(indexed);
+            }
+          );
+        }
+      }
+    );
+  });
+}
+
+// Run on startup to backfill existing unindexed rows
+indexNewShopItems().then((n) => {
+  if (n > 0) console.log(`Shop item index: backfilled ${n} item(s) on startup`);
+});
+
+// Run every 5 minutes to pick up newly created shops
+cron.schedule("*/5 * * * *", () => {
+  indexNewShopItems().then((n) => {
+    if (n > 0) console.log(`Shop item index: indexed ${n} new item(s)`);
+  });
+});

--- a/cron/shopItemIndexCron.js
+++ b/cron/shopItemIndexCron.js
@@ -2,23 +2,30 @@ import cron from "node-cron";
 import zlib from "zlib";
 import { quickshopDb } from "../controllers/databaseController.js";
 
-// Extract the Minecraft item ID from a base64+gzip-encoded NBT binary.
-// QuickShop-Hikari changed its storage format (around 2026-04-22, data id ~6000):
-// old format: item column = plain YAML text ("item:\n  id: minecraft:bow\n ...")
-// new format: item column = base64(gzip(NBT binary)) — same as the encoded column
-// The item ID is stored as a TAG_String with key "id" inside the NBT compound.
-function decodeNbtItemId(rawItem) {
+// Decode a base64+gzip NBT binary (QuickShop-Hikari new format, ~2026-04-22, id ≥ 6000)
+// and extract the item ID and count.  Returns { id, count } or null on failure.
+// NBT layout we rely on:
+//   TAG_String (0x08) key="id"    → item ID string e.g. "minecraft:diamond"
+//   TAG_Int    (0x03) key="count" → stack size as big-endian int32
+function decodeNbtItemData(rawItem) {
   try {
     const buf = Buffer.from(rawItem, "base64");
     const nbt = zlib.gunzipSync(buf);
-    // TAG_String = 0x08, followed by 2-byte key length, key bytes, 2-byte value length, value bytes
-    // We look for the sequence: 0x08 0x00 0x02 'i' 'd'
-    const pattern = Buffer.from([0x08, 0x00, 0x02, 0x69, 0x64]);
-    const idx = nbt.indexOf(pattern);
-    if (idx === -1) return null;
-    const valueLen = nbt.readUInt16BE(idx + 5);
-    const rawId = nbt.toString("utf8", idx + 7, idx + 7 + valueLen);
-    return rawId.replace("minecraft:", "");
+
+    // TAG_String = 0x08 | 2-byte key len | key bytes | 2-byte value len | value bytes
+    const idPattern = Buffer.from([0x08, 0x00, 0x02, 0x69, 0x64]); // \x08\x00\x02id
+    const idIdx = nbt.indexOf(idPattern);
+    if (idIdx === -1) return null;
+    const idLen = nbt.readUInt16BE(idIdx + 5);
+    const rawId = nbt.toString("utf8", idIdx + 7, idIdx + 7 + idLen);
+    const itemId = rawId.replace("minecraft:", "");
+
+    // TAG_Int = 0x03 | 2-byte key len | key bytes | 4-byte big-endian int32
+    const countPattern = Buffer.from([0x03, 0x00, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74]); // \x03\x00\x05count
+    const countIdx = nbt.indexOf(countPattern);
+    const count = countIdx !== -1 ? nbt.readInt32BE(countIdx + 8) : 1;
+
+    return { id: itemId, count };
   } catch {
     return null;
   }
@@ -26,8 +33,13 @@ function decodeNbtItemId(rawItem) {
 
 async function indexNewShopItems() {
   return new Promise((resolve) => {
+    // Pick up rows that are new-format AND either not yet indexed (name IS NULL)
+    // or previously indexed with the old plain-ID format (name NOT LIKE '{%').
     quickshopDb.query(
-      `SELECT id, item FROM qs_data WHERE item NOT LIKE 'item:%' AND name IS NULL LIMIT 500`,
+      `SELECT id, item FROM qs_data
+       WHERE item NOT LIKE 'item:%'
+         AND (name IS NULL OR name NOT LIKE '{%')
+       LIMIT 500`,
       (error, rows) => {
         if (error) {
           console.error("Shop item index query error:", error);
@@ -40,23 +52,16 @@ async function indexNewShopItems() {
         const total = rows.length;
 
         for (const row of rows) {
-          const itemId = decodeNbtItemId(row.item);
-          if (!itemId) {
-            // Mark as attempted with a placeholder so we don't retry forever
-            quickshopDb.query(
-              `UPDATE qs_data SET name = '' WHERE id = ? AND name IS NULL`,
-              [row.id],
-              () => { completed++; if (completed === total) resolve(indexed); }
-            );
-            continue;
-          }
+          const data = decodeNbtItemData(row.item);
+          // On decode failure store '{}' so we don't keep retrying this row
+          const nameValue = data ? JSON.stringify({ id: data.id, count: data.count }) : "{}";
           quickshopDb.query(
-            `UPDATE qs_data SET name = ? WHERE id = ? AND name IS NULL`,
-            [itemId, row.id],
+            `UPDATE qs_data SET name = ? WHERE id = ?`,
+            [nameValue, row.id],
             (err) => {
               if (err) {
                 console.error(`Shop index update error for data id=${row.id}:`, err);
-              } else {
+              } else if (data) {
                 indexed++;
               }
               completed++;

--- a/cron/shopItemIndexCron.js
+++ b/cron/shopItemIndexCron.js
@@ -26,62 +26,62 @@ function decodeNbtItemData(rawItem) {
     const count = countIdx !== -1 ? nbt.readInt32BE(countIdx + 8) : 1;
 
     return { id: itemId, count };
-  } catch {
+  } catch (err) {
     return null;
   }
 }
 
-async function indexNewShopItems() {
-  return new Promise((resolve) => {
-    // Pick up rows that are new-format AND either not yet indexed (name IS NULL)
-    // or previously indexed with the old plain-ID format (name NOT LIKE '{%').
-    quickshopDb.query(
-      `SELECT id, item FROM qs_data
-       WHERE item NOT LIKE 'item:%'
-         AND (name IS NULL OR name NOT LIKE '{%')
-       LIMIT 500`,
-      (error, rows) => {
-        if (error) {
-          console.error("Shop item index query error:", error);
-          return resolve(0);
-        }
-        if (!rows || rows.length === 0) return resolve(0);
-
-        let completed = 0;
-        let indexed = 0;
-        const total = rows.length;
-
-        for (const row of rows) {
-          const data = decodeNbtItemData(row.item);
-          // On decode failure store '{}' so we don't keep retrying this row
-          const nameValue = data ? JSON.stringify({ id: data.id, count: data.count }) : "{}";
-          quickshopDb.query(
-            `UPDATE qs_data SET name = ? WHERE id = ?`,
-            [nameValue, row.id],
-            (err) => {
-              if (err) {
-                console.error(`Shop index update error for data id=${row.id}:`, err);
-              } else if (data) {
-                indexed++;
-              }
-              completed++;
-              if (completed === total) resolve(indexed);
-            }
-          );
-        }
-      }
-    );
+function queryAsync(sql, params) {
+  return new Promise((resolve, reject) => {
+    quickshopDb.query(sql, params, (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
   });
 }
 
+async function indexNewShopItems() {
+  // Pick up rows that are new-format AND either not yet indexed (name IS NULL)
+  // or previously indexed with the old plain-ID format (name NOT LIKE '{%').
+  const rows = await queryAsync(
+    `SELECT id, item FROM qs_data
+     WHERE item NOT LIKE 'item:%'
+       AND (name IS NULL OR name NOT LIKE '{%')
+     LIMIT 500`,
+    []
+  );
+
+  if (!rows || rows.length === 0) return 0;
+
+  const updates = rows.map((row) => {
+    const data = decodeNbtItemData(row.item);
+    // On decode failure store '{}' so we don't keep retrying this row
+    const nameValue = data ? JSON.stringify({ id: data.id, count: data.count }) : "{}";
+    return queryAsync(`UPDATE qs_data SET name = ? WHERE id = ?`, [nameValue, row.id])
+      .then(() => (data ? 1 : 0))
+      .catch((err) => {
+        console.error(`Shop index update error for data id=${row.id}:`, err);
+        return 0;
+      });
+  });
+
+  const results = await Promise.all(updates);
+  return results.reduce((sum, n) => sum + n, 0);
+}
+
+async function runIndex(label) {
+  try {
+    const n = await indexNewShopItems();
+    if (n > 0) console.log(`Shop item index: ${label} ${n} item(s)`);
+  } catch (err) {
+    console.error("Shop item index error:", err);
+  }
+}
+
 // Run on startup to backfill existing unindexed rows
-indexNewShopItems().then((n) => {
-  if (n > 0) console.log(`Shop item index: backfilled ${n} item(s) on startup`);
-});
+runIndex("backfilled");
 
 // Run every 5 minutes to pick up newly created shops
 cron.schedule("*/5 * * * *", () => {
-  indexNewShopItems().then((n) => {
-    if (n > 0) console.log(`Shop item index: indexed ${n} new item(s)`);
-  });
+  runIndex("indexed");
 });

--- a/services/shopService.js
+++ b/services/shopService.js
@@ -257,7 +257,10 @@ export async function searchShops(material, page = 1, options = {}) {
            AND (
              (data.item LIKE 'item:%' AND (data.item LIKE ? OR data.item LIKE ?))
              OR
-             (data.item NOT LIKE 'item:%' AND (data.name LIKE ? OR data.name LIKE ?))
+             (data.item NOT LIKE 'item:%' AND (
+               JSON_UNQUOTE(JSON_EXTRACT(data.name, '$.id')) LIKE ?
+               OR JSON_UNQUOTE(JSON_EXTRACT(data.name, '$.id')) LIKE ?
+             ))
            )`,
         [likeTerm, likeTermUnderscored, likeTerm, likeTermUnderscored],
         (error, results) => {
@@ -292,10 +295,11 @@ export async function searchShops(material, page = 1, options = {}) {
                REPLACE(TRIM(SUBSTRING_INDEX(
                  SUBSTR(data.item, LOCATE('id:', data.item) + 3), '\n', 1
                )), 'minecraft:', '')
-             ELSE data.name
+             ELSE JSON_UNQUOTE(JSON_EXTRACT(data.name, '$.id'))
            END AS item,
            CASE
-             WHEN data.item NOT LIKE 'item:%' THEN NULL
+             WHEN data.item NOT LIKE 'item:%' THEN
+               JSON_EXTRACT(data.name, '$.count')
              WHEN LOCATE('count:', data.item) = 0 THEN NULL
              ELSE TRIM(SUBSTRING_INDEX(
                SUBSTR(data.item, LOCATE('count:', data.item) + 6), '\n', 1
@@ -346,7 +350,10 @@ export async function searchShops(material, page = 1, options = {}) {
            AND (
              (data.item LIKE 'item:%' AND (data.item LIKE ? OR data.item LIKE ?))
              OR
-             (data.item NOT LIKE 'item:%' AND (data.name LIKE ? OR data.name LIKE ?))
+             (data.item NOT LIKE 'item:%' AND (
+               JSON_UNQUOTE(JSON_EXTRACT(data.name, '$.id')) LIKE ?
+               OR JSON_UNQUOTE(JSON_EXTRACT(data.name, '$.id')) LIKE ?
+             ))
            )
          ORDER BY shops.id
          LIMIT ? OFFSET ?`,

--- a/services/shopService.js
+++ b/services/shopService.js
@@ -241,7 +241,11 @@ export async function searchShops(material, page = 1, options = {}) {
     const likeTerm = `%${material}%`;
     const likeTermUnderscored = `%${underscored}%`;
 
-    // Get total count for pagination
+    // Get total count for pagination.
+    // qs_data.item stores plain YAML for old shops and base64+gzip NBT for new ones
+    // (QuickShop-Hikari changed format ~2026-04-22, id ≥ 6000). The indexing cron
+    // decodes new-format rows and writes the bare item ID into data.name so we can
+    // still search them with a LIKE query.
     const totalCount = await new Promise((resolve, reject) => {
       quickshopDb.query(
         `SELECT COUNT(*) AS total
@@ -250,8 +254,12 @@ export async function searchShops(material, page = 1, options = {}) {
          JOIN qs_data data ON shops.data = data.id
          JOIN qs_external_cache stock ON shops.id = stock.shop
          WHERE data.unlimited = 0
-           AND (data.item LIKE ? OR data.item LIKE ?)`,
-        [likeTerm, likeTermUnderscored],
+           AND (
+             (data.item LIKE 'item:%' AND (data.item LIKE ? OR data.item LIKE ?))
+             OR
+             (data.item NOT LIKE 'item:%' AND (data.name LIKE ? OR data.name LIKE ?))
+           )`,
+        [likeTerm, likeTermUnderscored, likeTerm, likeTermUnderscored],
         (error, results) => {
           if (error) return reject(error);
           resolve(results[0]?.total || 0);
@@ -272,18 +280,26 @@ export async function searchShops(material, page = 1, options = {}) {
 
     // Fetch the page of results — replicate the shoppingDirectory VIEW logic
     // directly against the QuickShop pool (cross-server JOINs are not possible).
+    // For new-format shops (item NOT LIKE 'item:%'), the item ID comes from data.name
+    // (populated by shopItemIndexCron) and component extraction falls back to NULL.
     const results = await new Promise((resolve, reject) => {
       quickshopDb.query(
         `SELECT
            shops.id,
            data.owner AS uuid,
-           REPLACE(TRIM(SUBSTRING_INDEX(
-             SUBSTR(data.item, LOCATE('id:', data.item) + 3), '\n', 1
-           )), 'minecraft:', '') AS item,
-           CASE WHEN LOCATE('count:', data.item) = 0 THEN NULL
-                ELSE TRIM(SUBSTRING_INDEX(
-                  SUBSTR(data.item, LOCATE('count:', data.item) + 6), '\n', 1
-                ))
+           CASE
+             WHEN data.item LIKE 'item:%' THEN
+               REPLACE(TRIM(SUBSTRING_INDEX(
+                 SUBSTR(data.item, LOCATE('id:', data.item) + 3), '\n', 1
+               )), 'minecraft:', '')
+             ELSE data.name
+           END AS item,
+           CASE
+             WHEN data.item NOT LIKE 'item:%' THEN NULL
+             WHEN LOCATE('count:', data.item) = 0 THEN NULL
+             ELSE TRIM(SUBSTRING_INDEX(
+               SUBSTR(data.item, LOCATE('count:', data.item) + 6), '\n', 1
+             ))
            END AS amount,
            data.price,
            stock.stock,
@@ -292,6 +308,7 @@ export async function searchShops(material, page = 1, options = {}) {
            map.y,
            map.z,
            CASE
+             WHEN data.item NOT LIKE 'item:%' THEN NULL
              WHEN LOCATE('minecraft:stored_enchantments:', data.item) > 0
              THEN CONCAT(
                CONCAT(
@@ -326,10 +343,14 @@ export async function searchShops(material, page = 1, options = {}) {
          JOIN qs_data data ON shops.data = data.id
          JOIN qs_external_cache stock ON shops.id = stock.shop
          WHERE data.unlimited = 0
-           AND (data.item LIKE ? OR data.item LIKE ?)
+           AND (
+             (data.item LIKE 'item:%' AND (data.item LIKE ? OR data.item LIKE ?))
+             OR
+             (data.item NOT LIKE 'item:%' AND (data.name LIKE ? OR data.name LIKE ?))
+           )
          ORDER BY shops.id
          LIMIT ? OFFSET ?`,
-        [likeTerm, likeTermUnderscored, MAX_RESULTS, offset],
+        [likeTerm, likeTermUnderscored, likeTerm, likeTermUnderscored, MAX_RESULTS, offset],
         (error, results) => {
           if (error) return reject(error);
           resolve(results || []);


### PR DESCRIPTION
## Summary
This PR adds support for QuickShop-Hikari's new NBT-based item storage format (introduced ~2026-04-22 for shops with id ≥ 6000) while maintaining backward compatibility with the legacy YAML format. A new background cron job decodes NBT items and indexes them for searchability.

## Key Changes
- **New cron job** (`shopItemIndexCron.js`): Decodes base64+gzip NBT binary data to extract item IDs and stack counts, storing them in JSON format in the `qs_data.name` column for efficient searching. Runs on startup (backfill) and every 5 minutes (new shops).
- **NBT decoder**: Implements binary parsing of QuickShop-Hikari's NBT format to extract `id` (item type) and `count` (stack size) fields.
- **Updated search queries** (`shopService.js`): Modified `searchShops()` to handle both legacy (`item LIKE 'item:%'`) and new-format (`item NOT LIKE 'item:%'`) shops:
  - Legacy shops: Extract item ID from YAML-style `data.item` field
  - New-format shops: Extract item ID from indexed JSON in `data.name` field
  - Both count and enchantment extraction adapted accordingly
- **App initialization**: Imported the new cron module in `app.js` to enable automatic indexing.

## Implementation Details
- The NBT decoder uses binary pattern matching to locate TAG_String (id) and TAG_Int (count) fields within the decompressed NBT structure
- Failed decodes are marked with `{}` to prevent retry loops
- Search queries use conditional logic (CASE/WHEN) to route old vs. new format items to appropriate extraction methods
- Pagination and filtering work transparently across both formats
- Enchantment extraction is skipped for new-format items (returns NULL) as the format differs

https://claude.ai/code/session_01FZaNCRBv3m4PDqgki1uiQT